### PR TITLE
feat: use goreleaser default naming for published archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,20 +11,16 @@ builds:
       - GO111MODULE=on
       - CGO_ENABLED=0
     binary: ftw
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    targets:
+      - linux_amd64
+      - linux_arm64
+      - darwin_amd64
+      - darwin_arm64
+      - windows_amd64
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - format_overrides:
+    - goos: windows
+      format: zip
 checksum:
   name_template: '{{ .ProjectName }}-checksums.txt'
 snapshot:


### PR DESCRIPTION
This is just style so no worries if not going with this. I want to propose using goreleaser default naming scheme for release archives. goreleaser is very common now, and I like the consistency of archive names I see across various projects when writing tooling. I think it's worth doing that here.

Also publishes a windows-amd64 build (not arm64 since there is no viable platform for that yet)