### PR TITLE
fix: simplify sonar workflow and only run on push

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,33 +1,19 @@
 name: Sonar
 on:
-  workflow_run:
-    workflows: [test]
-    types: [completed]
+  push:
+    branches: [ main ]
+
 jobs:
   sonar:
     name: Sonar
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: goftw-code-coverage
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,3 @@ jobs:
 
       - name: Run Go Tests
         run: go test -coverprofile=coverage.out ./...
-
-      - name: Upload code coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: goftw-code-coverage
-          path: coverage.out
-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,5 +8,4 @@ sonar.projectName=go-ftw
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
 sonar.exclusions=**/*_test.go
-sonar.go.coverage.reportPaths=coverage.out
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
The sonar workflow has always been failing because it attempts to download an artifact uploaded from a different workflow - artifacts are scoped to builds so different workflows can't access them like that. From what I can tell, processing coverage with sonar is to show coverage report in sonarqube. Instead we should upload to codecov so it's open, and I can add that separately if this makes sense.

I also removed running Sonar on pull request because it won't work for PRs from forked repos due to the use of a secret - generally we can't run checks that require secrets on PRs in OSS projects so best to just fix forward if main fails.