### PR TITLE
fix: remove most uses of log.Fatal when running programatically

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,7 +56,7 @@ var runCmd = &cobra.Command{
 			excludeRE = regexp.MustCompile(exclude)
 		}
 
-		currentRun := runner.Run(tests, runner.Config{
+		currentRun, err := runner.Run(tests, runner.Config{
 			Include:        includeRE,
 			Exclude:        excludeRE,
 			ShowTime:       showTime,
@@ -64,6 +64,9 @@ var runCmd = &cobra.Command{
 			ConnectTimeout: connectTimeout,
 			ReadTimeout:    readTimeout,
 		})
+		if err != nil {
+			log.Fatal().Err(err)
+		}
 
 		os.Exit(currentRun.Stats.TotalFailed())
 	},

--- a/ftwhttp/client.go
+++ b/ftwhttp/client.go
@@ -21,17 +21,17 @@ func NewClientConfig() ClientConfig {
 }
 
 // NewClient initializes the http client, creating the cookiejar
-func NewClient(config ClientConfig) *Client {
+func NewClient(config ClientConfig) (*Client, error) {
 	// All users of cookiejar should import "golang.org/x/net/publicsuffix"
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
-		log.Fatal().Err(err)
+		return nil, err
 	}
 	c := &Client{
 		Jar:    jar,
 		config: config,
 	}
-	return c
+	return c, nil
 }
 
 // NewConnection creates a new Connection based on a Destination

--- a/ftwhttp/client_test.go
+++ b/ftwhttp/client_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 
 	assert.NotNil(t, c.Jar, "Error creating Client")
 }
@@ -19,9 +20,10 @@ func TestConnectDestinationHTTPS(t *testing.T) {
 		Protocol: "https",
 	}
 
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 
-	err := c.NewConnection(*d)
+	err = c.NewConnection(*d)
 	assert.NoError(t, err, "This should not error")
 	assert.Equal(t, "https", c.Transport.protocol, "Error connecting to example.com using https")
 }
@@ -33,11 +35,12 @@ func TestDoRequest(t *testing.T) {
 		Protocol: "https",
 	}
 
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 
 	req := generateBaseRequestForTesting()
 
-	err := c.NewConnection(*d)
+	err = c.NewConnection(*d)
 	assert.NoError(t, err, "This should not error")
 
 	_, err = c.Do(*req)
@@ -52,7 +55,8 @@ func TestGetTrackedTime(t *testing.T) {
 		Protocol: "https",
 	}
 
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 
 	rl := &RequestLine{
 		Method:  "POST",
@@ -65,7 +69,7 @@ func TestGetTrackedTime(t *testing.T) {
 	data := []byte(`test=me&one=two&one=twice`)
 	req := NewRequest(rl, h, data, true)
 
-	err := c.NewConnection(*d)
+	err = c.NewConnection(*d)
 	assert.NoError(t, err, "This should not error")
 
 	c.StartTrackingTime()
@@ -90,7 +94,8 @@ func TestClientMultipartFormDataRequest(t *testing.T) {
 		Protocol: "https",
 	}
 
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 
 	rl := &RequestLine{
 		Method:  "POST",
@@ -112,7 +117,7 @@ Some-file-test-here
 
 	req := NewRequest(rl, h, data, true)
 
-	err := c.NewConnection(*d)
+	err = c.NewConnection(*d)
 	assert.NoError(t, err, "This should not error")
 
 	c.StartTrackingTime()
@@ -127,7 +132,8 @@ Some-file-test-here
 }
 
 func TestNewConnectionCreatesTransport(t *testing.T) {
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 	assert.Nil(t, c.Transport, "Transport not expected to initialized yet")
 
 	server := testServer()
@@ -141,7 +147,8 @@ func TestNewConnectionCreatesTransport(t *testing.T) {
 }
 
 func TestNewOrReusedConnectionCreatesTransport(t *testing.T) {
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 	assert.Nil(t, c.Transport, "Transport not expected to initialized yet")
 
 	server := testServer()
@@ -155,7 +162,8 @@ func TestNewOrReusedConnectionCreatesTransport(t *testing.T) {
 }
 
 func TestNewOrReusedConnectionReusesTransport(t *testing.T) {
-	c := NewClient(NewClientConfig())
+	c, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 	assert.Nil(t, c.Transport, "Transport not expected to initialized yet")
 
 	server := testServer()

--- a/ftwhttp/connection.go
+++ b/ftwhttp/connection.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -82,7 +83,7 @@ func (c *Connection) Request(request *Request) error {
 	// Build request first, then connect and send, so timers are accurate
 	data, err := buildRequest(request)
 	if err != nil {
-		log.Fatal().Msgf("ftw/http: fatal error building request: %s", err.Error())
+		return fmt.Errorf("ftw/http: fatal error building request: %w", err)
 	}
 
 	log.Debug().Msgf("ftw/http: sending data:\n%s\n", data)

--- a/ftwhttp/response_test.go
+++ b/ftwhttp/response_test.go
@@ -88,7 +88,8 @@ func TestResponse(t *testing.T) {
 
 	req := generateRequestForTesting(true)
 
-	client := NewClient(NewClientConfig())
+	client, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 	err = client.NewConnection(*d)
 	assert.NoError(t, err)
 
@@ -107,7 +108,8 @@ func TestResponseWithCookies(t *testing.T) {
 	assert.NoError(t, err)
 	req := generateRequestForTesting(true)
 
-	client := NewClient(NewClientConfig())
+	client, err := NewClient(NewClientConfig())
+	assert.NoError(t, err)
 	err = client.NewConnection(*d)
 
 	assert.NoError(t, err)

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -83,9 +83,6 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 // logFile is the file to search
 // stageID is the ID of the current stage, which is part of the marker line
 func (ll *FTWLogLines) CheckLogForMarker(stageID string) []byte {
-	if config.FTWConfig.RunMode == config.DefaultRunMode && ll.logFile == nil {
-		log.Fatal().Caller().Msg("No log file supplied")
-	}
 	offset, err := ll.logFile.Seek(0, os.SEEK_END)
 	if err != nil {
 		log.Error().Caller().Err(err).Msgf("failed to seek end of log file")

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -31,7 +31,8 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll := NewFTWLogLines(WithStartMarker(bytes.ToLower([]byte(markerLine))))
+	ll, err := NewFTWLogLines(WithStartMarker(bytes.ToLower([]byte(markerLine))))
+	assert.NoError(t, err)
 
 	marker := ll.CheckLogForMarker(stageID)
 	assert.Nil(t, marker, "unexpectedly found marker")
@@ -54,7 +55,8 @@ func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll := NewFTWLogLines(WithStartMarker(bytes.ToLower([]byte(markerLine))))
+	ll, err := NewFTWLogLines(WithStartMarker(bytes.ToLower([]byte(markerLine))))
+	assert.NoError(t, err)
 
 	marker := ll.CheckLogForMarker(stageID)
 	assert.NotNil(t, marker, "no marker found")
@@ -80,9 +82,10 @@ func TestReadGetMarkedLines(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll := NewFTWLogLines(
+	ll, err := NewFTWLogLines(
 		WithStartMarker(bytes.ToLower([]byte(startMarkerLine))),
 		WithEndMarker(bytes.ToLower([]byte(endMarkerLine))))
+	assert.NoError(t, err)
 
 	foundLines := ll.getMarkedLines()
 	// logs are scanned backwards
@@ -116,9 +119,10 @@ func TestReadGetMarkedLinesWithTrailingEmptyLines(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll := NewFTWLogLines(
+	ll, err := NewFTWLogLines(
 		WithStartMarker(bytes.ToLower([]byte(startMarkerLine))),
 		WithEndMarker(bytes.ToLower([]byte(endMarkerLine))))
+	assert.NoError(t, err)
 
 	foundLines := ll.getMarkedLines()
 	// logs are scanned backwards
@@ -155,9 +159,10 @@ func TestReadGetMarkedLinesWithPrecedingLines(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll := NewFTWLogLines(
+	ll, err := NewFTWLogLines(
 		WithStartMarker(bytes.ToLower([]byte(startMarkerLine))),
 		WithEndMarker(bytes.ToLower([]byte(endMarkerLine))))
+	assert.NoError(t, err)
 
 	foundLines := ll.getMarkedLines()
 	// logs are scanned backwards

--- a/waflog/waflog.go
+++ b/waflog/waflog.go
@@ -1,15 +1,17 @@
 package waflog
 
 import (
+	"errors"
+	"fmt"
 	"os"
-
-	"github.com/rs/zerolog/log"
 
 	"github.com/coreruleset/go-ftw/config"
 )
 
+var errNoLogFile = errors.New("no log file supplied")
+
 // NewFTWLogLines is the base struct for reading the log file
-func NewFTWLogLines(opts ...FTWLogOption) *FTWLogLines {
+func NewFTWLogLines(opts ...FTWLogOption) (*FTWLogLines, error) {
 	ll := &FTWLogLines{
 		logFile:     nil,
 		FileName:    config.FTWConfig.LogFile,
@@ -25,10 +27,14 @@ func NewFTWLogLines(opts ...FTWLogOption) *FTWLogLines {
 	}
 
 	if err := ll.openLogFile(); err != nil {
-		log.Error().Caller().Msgf("cannot open log file: %s", err)
+		return nil, fmt.Errorf("cannot open log file: %w", err)
 	}
 
-	return ll
+	if config.FTWConfig.RunMode == config.DefaultRunMode && ll.logFile == nil {
+		return nil, errNoLogFile
+	}
+
+	return ll, nil
 }
 
 // WithStartMarker sets the start marker for the log file

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -12,7 +12,8 @@ func TestNewFTWLogLines(t *testing.T) {
 	err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
 
-	ll := NewFTWLogLines()
+	// Don't call NewFTWLogLines to avoid opening the file.
+	ll := &FTWLogLines{}
 	// Loop through each option
 	for _, opt := range []FTWLogOption{
 		WithStartMarker([]byte("#")),


### PR DESCRIPTION
go-ftw provides a programmatic entry point for tests like this one

https://github.com/corazawaf/coraza/blob/v3/dev/testing/coreruleset/coreruleset_test.go#L213

There are some quirks like global config (will look at in another PR) and the code causing the process to exit because of use of `log.Fatal`, making test failures difficult to understand. This replaces `log.Fatal` with propagating errors. There is one remaining Fatal for a regexp which will require some less mechanical change but that also should have lower chance of triggering