### PR TITLE
ci: setup buildx for release docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
         with:
           fetch-depth: 0
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- setup buildx before calling goreleaser