### PR TITLE
feat: only output failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ logfile: 'tests/logs/modsec3-nginx/error.log'
 
 This is the help for the `run` command:
 ```bash
-❯ ftw run -h
+❯ ./ftw run --help
 Run all tests below a certain subdirectory. The command will search all y[a]ml files recursively and pass it to the test engine.
 
 Usage:
@@ -121,11 +121,12 @@ Usage:
 Flags:
       --connect-timeout duration   timeout for connecting to endpoints during test execution (default 3s)
   -d, --dir string                 recursively find yaml tests in this directory (default ".")
-  -e, --exclude string             exclude tests matching this Go regexp (e.g. to exclude all tests beginning with "91", use "91.*").
+  -e, --exclude string             exclude tests matching this Go regexp (e.g. to exclude all tests beginning with "91", use "91.*"). 
                                    If you want more permanent exclusion, check the 'testoverride' option in the config file.
   -h, --help                       help for run
       --id string                  (deprecated). Use --include matching your test only.
   -i, --include string             include only tests matching this Go regexp (e.g. to include only tests beginning with "91", use "91.*").
+      --output-failures-only       output only the result of failed tests
   -q, --quiet                      do not show test by test, only results
       --read-timeout duration      timeout for receiving responses during test execution (default 1s)
   -t, --time                       show time spent per test
@@ -135,6 +136,7 @@ Global Flags:
       --config string   override config file (default is $PWD/.ftw.yaml)
       --debug           debug output
       --trace           trace output: really, really verbose
+
 ```
 
 Here's an example on how to run your tests recursively in the folder `tests`:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,6 +26,7 @@ var runCmd = &cobra.Command{
 		id, _ := cmd.Flags().GetString("id")
 		dir, _ := cmd.Flags().GetString("dir")
 		showTime, _ := cmd.Flags().GetBool("time")
+		showOnlyFailed, _ := cmd.Flags().GetBool("output-failures-only")
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		connectTimeout, _ := cmd.Flags().GetDuration("connect-timeout")
 		readTimeout, _ := cmd.Flags().GetDuration("read-timeout")
@@ -61,6 +62,7 @@ var runCmd = &cobra.Command{
 			Exclude:        excludeRE,
 			ShowTime:       showTime,
 			Quiet:          quiet,
+			ShowOnlyFailed: showOnlyFailed,
 			ConnectTimeout: connectTimeout,
 			ReadTimeout:    readTimeout,
 		})
@@ -80,6 +82,7 @@ func init() {
 	runCmd.Flags().StringP("dir", "d", ".", "recursively find yaml tests in this directory")
 	runCmd.Flags().BoolP("quiet", "q", false, "do not show test by test, only results")
 	runCmd.Flags().BoolP("time", "t", false, "show time spent per test")
+	runCmd.Flags().BoolP("output-failures-only", "", false, "output only the result of failed tests")
 	runCmd.Flags().Duration("connect-timeout", 3*time.Second, "timeout for connecting to endpoints during test execution")
 	runCmd.Flags().Duration("read-timeout", 1*time.Second, "timeout for receiving responses during test execution")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -82,7 +82,7 @@ func init() {
 	runCmd.Flags().StringP("dir", "d", ".", "recursively find yaml tests in this directory")
 	runCmd.Flags().BoolP("quiet", "q", false, "do not show test by test, only results")
 	runCmd.Flags().BoolP("time", "t", false, "show time spent per test")
-	runCmd.Flags().BoolP("output-failures-only", "", false, "output only the result of failed tests")
+	runCmd.Flags().BoolP("output-failures-only", "", false, "output only the results of failed tests")
 	runCmd.Flags().Duration("connect-timeout", 3*time.Second, "timeout for connecting to endpoints during test execution")
 	runCmd.Flags().Duration("read-timeout", 1*time.Second, "timeout for receiving responses during test execution")
 }

--- a/runner/types.go
+++ b/runner/types.go
@@ -19,6 +19,8 @@ type Config struct {
 	ShowTime bool
 	// Quiet determines whether to output informational messages.
 	Quiet bool
+	// ShowOnlyFailed will only output information related to failed tests
+	ShowOnlyFailed bool
 	// ConnectTimeout is the timeout for connecting to endpoints during test execution.
 	ConnectTimeout time.Duration
 	// ReadTimeout is the timeout for receiving responses during test execution.
@@ -29,14 +31,15 @@ type Config struct {
 // This includes both configuration information as well as statistics
 // and results.
 type TestRunContext struct {
-	Include  *regexp.Regexp
-	Exclude  *regexp.Regexp
-	ShowTime bool
-	Output   bool
-	Stats    TestStats
-	Result   TestResult
-	Duration time.Duration
-	Client   *ftwhttp.Client
-	LogLines *waflog.FTWLogLines
-	RunMode  config.RunMode
+	Include        *regexp.Regexp
+	Exclude        *regexp.Regexp
+	ShowTime       bool
+	Output         bool
+	ShowOnlyFailed bool
+	Stats          TestStats
+	Result         TestResult
+	Duration       time.Duration
+	Client         *ftwhttp.Client
+	LogLines       *waflog.FTWLogLines
+	RunMode        config.RunMode
 }


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- adds `--output-failures-only` flag

Fixes #81.