### PR TITLE
fix: look more than one line for log markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ logfile: 'tests/logs/modsec3-nginx/error.log'
 
 This is the help for the `run` command:
 ```bash
-❯ ./ftw run --help
-Run all tests below a certain subdirectory. The command will search all y[a]ml files recursively and pass it to the test engine.
+./ftw run --help
+ Run all tests below a certain subdirectory. The command will search all y[a]ml files recursively and pass it to the test engine.
 
 Usage:
   ftw run [flags]
@@ -126,7 +126,10 @@ Flags:
   -h, --help                       help for run
       --id string                  (deprecated). Use --include matching your test only.
   -i, --include string             include only tests matching this Go regexp (e.g. to include only tests beginning with "91", use "91.*").
-      --output-failures-only       output only the result of failed tests
+      --max-marker-log-lines int   maximum number of lines to search for a marker before aborting (default 500)
+      --max-marker-retries int     maximum number of times the search for log markers will be repeated.
+                                   Each time an additional request is sent to the web server, eventually forcing the log to be flushed (default 20)
+      --output-failures-only       output only the results of failed tests
   -q, --quiet                      do not show test by test, only results
       --read-timeout duration      timeout for receiving responses during test execution (default 1s)
   -t, --time                       show time spent per test
@@ -136,7 +139,6 @@ Global Flags:
       --config string   override config file (default is $PWD/.ftw.yaml)
       --debug           debug output
       --trace           trace output: really, really verbose
-
 ```
 
 Here's an example on how to run your tests recursively in the folder `tests`:

--- a/check/base.go
+++ b/check/base.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"bytes"
+
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/test"
 	"github.com/coreruleset/go-ftw/waflog"
@@ -109,10 +111,10 @@ func (c *FTWCheck) SetCloudMode() {
 
 // SetStartMarker sets the log line that marks the start of the logs to analyze
 func (c *FTWCheck) SetStartMarker(marker []byte) {
-	c.log.StartMarker = marker
+	c.log.StartMarker = bytes.ToLower(marker)
 }
 
 // SetEndMarker sets the log line that marks the end of the logs to analyze
 func (c *FTWCheck) SetEndMarker(marker []byte) {
-	c.log.EndMarker = marker
+	c.log.EndMarker = bytes.ToLower(marker)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -90,6 +90,6 @@ func init() {
 	runCmd.Flags().BoolP("show-failures-only", "", false, "shows only the results of failed tests")
 	runCmd.Flags().Duration("connect-timeout", 3*time.Second, "timeout for connecting to endpoints during test execution")
 	runCmd.Flags().Duration("read-timeout", 1*time.Second, "timeout for receiving responses during test execution")
-	runCmd.Flags().Int("max-marker-retries", 20, "maximum number of times the search for log markers will be repeated; each time an additional request is sent to the web server, eventually forcing the log to be flushed")
+	runCmd.Flags().Int("max-marker-retries", 20, "maximum number of times the search for log markers will be repeated.\nEach time an additional request is sent to the web server, eventually forcing the log to be flushed")
 	runCmd.Flags().Int("max-marker-log-lines", 500, "maximum number of lines to search for a marker before aborting")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/coreruleset/go-ftw/output"
 	"os"
 	"regexp"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/coreruleset/go-ftw/output"
 	"github.com/coreruleset/go-ftw/runner"
 	"github.com/coreruleset/go-ftw/test"
 )
@@ -29,6 +29,8 @@ var runCmd = &cobra.Command{
 		wantedOutput, _ := cmd.Flags().GetString("output")
 		connectTimeout, _ := cmd.Flags().GetDuration("connect-timeout")
 		readTimeout, _ := cmd.Flags().GetDuration("read-timeout")
+		maxMarkerRetries, _ := cmd.Flags().GetInt("max-marker-retries")
+		maxMarkerLogLines, _ := cmd.Flags().GetInt("max-marker-log-lines")
 
 		if wantedOutput == "" {
 			wantedOutput = "normal"
@@ -60,12 +62,14 @@ var runCmd = &cobra.Command{
 		_ = out.Println("%s", out.Message("** Starting tests!"))
 
 		currentRun, err := runner.Run(tests, runner.Config{
-			Include:        includeRE,
-			Exclude:        excludeRE,
-			ShowTime:       showTime,
-			ShowOnlyFailed: showOnlyFailed,
-			ConnectTimeout: connectTimeout,
-			ReadTimeout:    readTimeout,
+			Include:           includeRE,
+			Exclude:           excludeRE,
+			ShowTime:          showTime,
+			ShowOnlyFailed:    showOnlyFailed,
+			ConnectTimeout:    connectTimeout,
+			ReadTimeout:       readTimeout,
+			MaxMarkerRetries:  maxMarkerRetries,
+			MaxMarkerLogLines: maxMarkerLogLines,
 		}, out)
 		if err != nil {
 			log.Fatal().Err(err)
@@ -86,4 +90,6 @@ func init() {
 	runCmd.Flags().BoolP("show-failures-only", "", false, "shows only the results of failed tests")
 	runCmd.Flags().Duration("connect-timeout", 3*time.Second, "timeout for connecting to endpoints during test execution")
 	runCmd.Flags().Duration("read-timeout", 1*time.Second, "timeout for receiving responses during test execution")
+	runCmd.Flags().Int("max-marker-retries", 20, "maximum number of times the search for log markers will be repeated; each time an additional request is sent to the web server, eventually forcing the log to be flushed")
+	runCmd.Flags().Int("max-marker-log-lines", 500, "maximum number of lines to search for a marker before aborting")
 }

--- a/runner/types.go
+++ b/runner/types.go
@@ -1,9 +1,10 @@
 package runner
 
 import (
-	"github.com/coreruleset/go-ftw/output"
 	"regexp"
 	"time"
+
+	"github.com/coreruleset/go-ftw/output"
 
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/ftwhttp"
@@ -26,21 +27,27 @@ type Config struct {
 	ConnectTimeout time.Duration
 	// ReadTimeout is the timeout for receiving responses during test execution.
 	ReadTimeout time.Duration
+	// MaxMarkerRetries is the maximum number of times the search for log markers will be repeated; each time an additional request is sent to the web server, eventually forcing the log to be flushed
+	MaxMarkerRetries int
+	// MaxMarkerLogLines is the maximum number of lines to search for a marker before aborting
+	MaxMarkerLogLines int
 }
 
 // TestRunContext carries information about the current test run.
 // This includes configuration information as well as statistics
 // and results.
 type TestRunContext struct {
-	Include        *regexp.Regexp
-	Exclude        *regexp.Regexp
-	ShowTime       bool
-	ShowOnlyFailed bool
-	Output         *output.Output
-	Stats          *RunStats
-	Result         TestResult
-	Duration       time.Duration
-	Client         *ftwhttp.Client
-	LogLines       *waflog.FTWLogLines
-	RunMode        config.RunMode
+	Include           *regexp.Regexp
+	Exclude           *regexp.Regexp
+	ShowTime          bool
+	ShowOnlyFailed    bool
+	MaxMarkerRetries  int
+	MaxMarkerLogLines int
+	Output            *output.Output
+	Stats             *RunStats
+	Result            TestResult
+	Duration          time.Duration
+	Client            *ftwhttp.Client
+	LogLines          *waflog.FTWLogLines
+	RunMode           config.RunMode
 }

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -31,7 +31,7 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(WithStartMarker(bytes.ToLower([]byte(markerLine))))
+	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
 	assert.NoError(t, err)
 
 	marker := ll.CheckLogForMarker(stageID)
@@ -242,11 +242,108 @@ func TestFTWLogLines_Contains(t *testing.T) {
 			ll := &FTWLogLines{
 				logFile:     tt.fields.logFile,
 				FileName:    tt.fields.FileName,
-				StartMarker: tt.fields.StartMarker,
-				EndMarker:   tt.fields.EndMarker,
+				StartMarker: bytes.ToLower(tt.fields.StartMarker),
+				EndMarker:   bytes.ToLower(tt.fields.EndMarker),
 			}
 			got := ll.Contains(tt.args.match)
 			assert.Equalf(t, tt.want, got, "Contains() = %v, want %v", got, tt.want)
 		})
 	}
+}
+
+func TestFTWLogLines_ContainsIn404(t *testing.T) {
+	err := config.NewConfigFromEnv()
+	assert.NoError(t, err)
+
+	stageID := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLine := fmt.Sprint(`[2022-11-12 23:08:18.012572] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
+		"X-cRs-TeSt ", stageID,
+		`"] [hostname "localhost"] [uri "/status/200"] [unique_id "Y3AZUo3Gja4gB-tPE9uasgAAAA4"]`)
+	logLines := fmt.Sprint("\n", markerLine,
+		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`,
+		`[2022-11-12 23:08:18.013007] [core:info] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 AH00128: File does not exist: /apache/htdocs/status/200`,
+		"\n", markerLine)
+	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
+	assert.NoError(t, err)
+
+	config.FTWConfig.LogFile = filename
+	log, err := os.Open(filename)
+	assert.NoError(t, err)
+
+	t.Cleanup(func() { os.Remove(filename) })
+
+	type fields struct {
+		logFile     *os.File
+		FileName    string
+		StartMarker []byte
+		EndMarker   []byte
+	}
+	f := fields{
+		logFile:     log,
+		FileName:    filename,
+		StartMarker: []byte(markerLine),
+		EndMarker:   []byte(markerLine),
+	}
+
+	type args struct {
+		match string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "Test contains element",
+			fields: f,
+			args: args{
+				match: "999999",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ll := &FTWLogLines{
+				logFile:     tt.fields.logFile,
+				FileName:    tt.fields.FileName,
+				StartMarker: bytes.ToLower(tt.fields.StartMarker),
+				EndMarker:   bytes.ToLower(tt.fields.EndMarker),
+			}
+			got := ll.Contains(tt.args.match)
+			assert.Equalf(t, tt.want, got, "Contains() = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+func TestFTWLogLines_CheckForLogMarkerIn404(t *testing.T) {
+	err := config.NewConfigFromEnv()
+	assert.NoError(t, err)
+
+	stageID := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLine := fmt.Sprint(`[2022-11-12 23:08:18.012572] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
+		"X-cRs-TeSt ", stageID,
+		`"] [hostname "localhost"] [uri "/status/200"] [unique_id "Y3AZUo3Gja4gB-tPE9uasgAAAA4"]`)
+	logLines := fmt.Sprint("\n", markerLine,
+		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`,
+		`[2022-11-12 23:08:18.013007] [core:info] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 AH00128: File does not exist: /apache/htdocs/status/200`,
+		"\n", markerLine)
+	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
+	assert.NoError(t, err)
+
+	config.FTWConfig.LogFile = filename
+	log, err := os.Open(filename)
+	assert.NoError(t, err)
+
+	t.Cleanup(func() { os.Remove(filename) })
+
+	ll := &FTWLogLines{
+		logFile:     log,
+		FileName:    filename,
+		StartMarker: bytes.ToLower([]byte(markerLine)),
+		EndMarker:   bytes.ToLower([]byte(markerLine)),
+	}
+	foundMarker := ll.CheckLogForMarker(stageID)
+	assert.Equal(t, strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))
 }

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -34,8 +34,9 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
 	assert.NoError(t, err)
 
-	marker := ll.CheckLogForMarker(stageID)
-	assert.Nil(t, marker, "unexpectedly found marker")
+	marker, aborted := ll.CheckLogForMarker(stageID, 100)
+	assert.Equal(t, string(marker), strings.ToLower(markerLine), "unexpectedly found marker")
+	assert.False(t, aborted)
 }
 
 func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
@@ -55,13 +56,14 @@ func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
 	config.FTWConfig.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(WithStartMarker(bytes.ToLower([]byte(markerLine))))
+	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
 	assert.NoError(t, err)
 
-	marker := ll.CheckLogForMarker(stageID)
+	marker, aborted := ll.CheckLogForMarker(stageID, 100)
 	assert.NotNil(t, marker, "no marker found")
 
 	assert.Equal(t, marker, bytes.ToLower([]byte(markerLine)), "found unexpected marker")
+	assert.False(t, aborted)
 }
 
 func TestReadGetMarkedLines(t *testing.T) {
@@ -344,6 +346,7 @@ func TestFTWLogLines_CheckForLogMarkerIn404(t *testing.T) {
 		StartMarker: bytes.ToLower([]byte(markerLine)),
 		EndMarker:   bytes.ToLower([]byte(markerLine)),
 	}
-	foundMarker := ll.CheckLogForMarker(stageID)
+	foundMarker, aborted := ll.CheckLogForMarker(stageID, 100)
 	assert.Equal(t, strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))
+	assert.False(t, aborted)
 }

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -34,9 +34,8 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
 	assert.NoError(t, err)
 
-	marker, aborted := ll.CheckLogForMarker(stageID, 100)
+	marker := ll.CheckLogForMarker(stageID, 100)
 	assert.Equal(t, string(marker), strings.ToLower(markerLine), "unexpectedly found marker")
-	assert.False(t, aborted)
 }
 
 func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
@@ -59,11 +58,10 @@ func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
 	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
 	assert.NoError(t, err)
 
-	marker, aborted := ll.CheckLogForMarker(stageID, 100)
+	marker := ll.CheckLogForMarker(stageID, 100)
 	assert.NotNil(t, marker, "no marker found")
 
 	assert.Equal(t, marker, bytes.ToLower([]byte(markerLine)), "found unexpected marker")
-	assert.False(t, aborted)
 }
 
 func TestReadGetMarkedLines(t *testing.T) {
@@ -346,7 +344,6 @@ func TestFTWLogLines_CheckForLogMarkerIn404(t *testing.T) {
 		StartMarker: bytes.ToLower([]byte(markerLine)),
 		EndMarker:   bytes.ToLower([]byte(markerLine)),
 	}
-	foundMarker, aborted := ll.CheckLogForMarker(stageID, 100)
+	foundMarker := ll.CheckLogForMarker(stageID, 100)
 	assert.Equal(t, strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))
-	assert.False(t, aborted)
 }

--- a/waflog/waflog.go
+++ b/waflog/waflog.go
@@ -1,6 +1,7 @@
 package waflog
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -40,14 +41,14 @@ func NewFTWLogLines(opts ...FTWLogOption) (*FTWLogLines, error) {
 // WithStartMarker sets the start marker for the log file
 func WithStartMarker(marker []byte) FTWLogOption {
 	return func(ll *FTWLogLines) {
-		ll.StartMarker = marker
+		ll.StartMarker = bytes.ToLower(marker)
 	}
 }
 
 // WithEndMarker sets the end marker for the log file
 func WithEndMarker(marker []byte) FTWLogOption {
 	return func(ll *FTWLogLines) {
-		ll.EndMarker = marker
+		ll.EndMarker = bytes.ToLower(marker)
 	}
 }
 


### PR DESCRIPTION
Look back an additional line and do not assume that the marker will appear on the last line. httpd will write the 404 error **after** the ModSecurity output (depending on the log level).

This commit also fixes some casing issues that might occur, especially in case of tests.

Fixes #104.