### PR TITLE
chore: removes a misleading comment

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -20,7 +20,7 @@ import (
 
 var errBadTestRequest = errors.New("ftw/run: bad test: choose between data, encoded_request, or raw_request")
 
-// Run runs your tests with the specified Config. Returns error if some test failed
+// Run runs your tests with the specified Config.
 func Run(tests []test.FTWTest, c Config, out *output.Output) (TestRunContext, error) {
 	out.Println("%s", out.Message("** Running go-ftw!"))
 


### PR DESCRIPTION
Hi there, another small nit. [Updating go-ftw used inside Coraza](https://github.com/corazawaf/coraza/pull/516) I found this comment that may be misleading.
```
// Run runs your tests with the specified Config. Returns error if some test failed
```
It seems that errors are returned when problems happen when testing, and are not related to failed tests.
E.g.: Here failed tests are still printed during  `os.Exit` not when the `err` is checked:
https://github.com/coreruleset/go-ftw/blob/acafe99202eeecebbf57f26c9827d6f169067194/cmd/run.go#L74-L78

Am I missing something? Otherwise, I'm just removing the second part of the comment. 

Thank you! 