### PR TITLE
feat: move config to parameter instead of global

### DIFF
--- a/check/base.go
+++ b/check/base.go
@@ -10,21 +10,19 @@ import (
 
 // FTWCheck is the base struct for checking test results
 type FTWCheck struct {
-	log       *waflog.FTWLogLines
-	expected  *test.Output
-	overrides *config.FTWTestOverride
+	log      *waflog.FTWLogLines
+	expected *test.Output
+	cfg      *config.FTWConfiguration
 }
 
 // NewCheck creates a new FTWCheck, allowing to inject the configuration
 func NewCheck(c *config.FTWConfiguration) *FTWCheck {
+	//TODO: check error
+	ll, _ := waflog.NewFTWLogLines(c)
 	check := &FTWCheck{
-		log: &waflog.FTWLogLines{
-			FileName:    c.LogFile,
-			StartMarker: nil,
-			EndMarker:   nil,
-		},
-		expected:  &test.Output{},
-		overrides: &c.TestOverride,
+		log:      ll,
+		cfg:      c,
+		expected: &test.Output{},
 	}
 
 	return check
@@ -62,7 +60,7 @@ func (c *FTWCheck) SetNoLogContains(contains string) {
 
 // ForcedIgnore check if this id need to be ignored from results
 func (c *FTWCheck) ForcedIgnore(id string) bool {
-	for re := range c.overrides.Ignore {
+	for re := range c.cfg.TestOverride.Ignore {
 		if re.MatchString(id) {
 			return true
 		}
@@ -72,7 +70,7 @@ func (c *FTWCheck) ForcedIgnore(id string) bool {
 
 // ForcedPass check if this id need to be ignored from results
 func (c *FTWCheck) ForcedPass(id string) bool {
-	for re := range c.overrides.ForcePass {
+	for re := range c.cfg.TestOverride.ForcePass {
 		if re.MatchString(id) {
 			return true
 		}
@@ -82,7 +80,7 @@ func (c *FTWCheck) ForcedPass(id string) bool {
 
 // ForcedFail check if this id need to be ignored from results
 func (c *FTWCheck) ForcedFail(id string) bool {
-	for re := range c.overrides.ForceFail {
+	for re := range c.cfg.TestOverride.ForceFail {
 		if re.MatchString(id) {
 			return true
 		}
@@ -92,7 +90,7 @@ func (c *FTWCheck) ForcedFail(id string) bool {
 
 // CloudMode returns true if we are running in cloud mode
 func (c *FTWCheck) CloudMode() bool {
-	return config.FTWConfig.RunMode == config.CloudRunMode
+	return c.cfg.RunMode == config.CloudRunMode
 }
 
 // SetCloudMode alters the values for expected logs and status code

--- a/check/base_test.go
+++ b/check/base_test.go
@@ -26,12 +26,12 @@ mode: "cloud"
 `
 
 func TestNewCheck(t *testing.T) {
-	err := config.NewConfigFromString(yamlNginxConfig)
+	cfg, err := config.NewConfigFromString(yamlNginxConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
-	for _, text := range c.overrides.Ignore {
+	for _, text := range c.cfg.TestOverride.Ignore {
 		assert.Equal(t, text, "Ignore Me", "Well, didn't match Ignore Me")
 	}
 
@@ -52,10 +52,10 @@ func TestNewCheck(t *testing.T) {
 }
 
 func TestForced(t *testing.T) {
-	err := config.NewConfigFromString(yamlNginxConfig)
+	cfg, err := config.NewConfigFromString(yamlNginxConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
 	assert.True(t, c.ForcedIgnore("942200-1"), "Can't find ignored value")
 
@@ -65,10 +65,10 @@ func TestForced(t *testing.T) {
 }
 
 func TestCloudMode(t *testing.T) {
-	err := config.NewConfigFromString(yamlCloudConfig)
+	cfg, err := config.NewConfigFromString(yamlCloudConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
 	assert.True(t, c.CloudMode(), "couldn't detect cloud mode")
 

--- a/check/error_test.go
+++ b/check/error_test.go
@@ -26,10 +26,10 @@ var expectedFailTests = []struct {
 }
 
 func TestAssertResponseErrorOK(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 	for _, e := range expectedOKTests {
 		c.SetExpectError(e.expected)
 		assert.Equal(t, e.expected, c.AssertExpectError(e.err))
@@ -37,10 +37,10 @@ func TestAssertResponseErrorOK(t *testing.T) {
 }
 
 func TestAssertResponseFail(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
 	for _, e := range expectedFailTests {
 		c.SetExpectError(e.expected)

--- a/check/logs_test.go
+++ b/check/logs_test.go
@@ -17,14 +17,14 @@ var logText = `[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 1396834345
 `
 
 func TestAssertLogContainsOK(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
 	logName, _ := utils.CreateTempFileWithContent(logText, "test-*.log")
 	defer os.Remove(logName)
-	config.FTWConfig.LogFile = logName
+	cfg.WithLogfile(logName)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
 	c.SetLogContains(`id "920300"`)
 	assert.True(t, c.AssertLogContains(), "did not find expected content 'id \"920300\"'")

--- a/check/response_test.go
+++ b/check/response_test.go
@@ -23,10 +23,10 @@ var expectedResponseFailTests = []struct {
 }
 
 func TestAssertResponseTextErrorOK(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 	for _, e := range expectedResponseOKTests {
 		c.SetExpectResponse(e.expected)
 		assert.Truef(t, c.AssertResponseContains(e.response), "unexpected response: %v", e.response)
@@ -34,10 +34,10 @@ func TestAssertResponseTextErrorOK(t *testing.T) {
 }
 
 func TestAssertResponseTextFailOK(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 	for _, e := range expectedResponseFailTests {
 		c.SetExpectResponse(e.expected)
 		assert.Falsef(t, c.AssertResponseContains(e.response), "response shouldn't contain text %v", e.response)

--- a/check/status_test.go
+++ b/check/status_test.go
@@ -26,10 +26,10 @@ var statusFailTests = []struct {
 }
 
 func TestStatusOK(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
 	for _, expected := range statusOKTests {
 		c.SetExpectStatus(expected.expectedStatus)
@@ -38,10 +38,10 @@ func TestStatusOK(t *testing.T) {
 }
 
 func TestStatusFail(t *testing.T) {
-	err := config.NewConfigFromString(yamlApacheConfig)
+	cfg, err := config.NewConfigFromString(yamlApacheConfig)
 	assert.NoError(t, err)
 
-	c := NewCheck(config.FTWConfig)
+	c := NewCheck(cfg)
 
 	for _, expected := range statusFailTests {
 		c.SetExpectStatus(expected.expectedStatus)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@ var (
 	cloud   bool
 )
 
+var cfg = config.NewDefaultConfig()
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "ftw run",
@@ -52,14 +54,15 @@ func initConfig() {
 	if trace {
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	}
-	errFile := config.NewConfigFromFile(cfgFile)
+	cfg, errFile := config.NewConfigFromFile(cfgFile)
 	if errFile != nil {
-		errEnv := config.NewConfigFromEnv()
+		cfgenv, errEnv := config.NewConfigFromEnv()
 		if errEnv != nil {
 			log.Fatalf("cannot read config from file (%s) nor environment (%s).", errFile.Error(), errEnv.Error())
 		}
+		cfg = cfgenv
 	}
 	if cloud {
-		config.FTWConfig.RunMode = config.CloudRunMode
+		cfg.RunMode = config.CloudRunMode
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,7 +64,7 @@ var runCmd = &cobra.Command{
 		out := output.NewOutput(wantedOutput, os.Stdout)
 		_ = out.Println("%s", out.Message("** Starting tests!"))
 
-		currentRun, err := runner.Run(cfg, tests, runner.Config{
+		currentRun, err := runner.Run(cfg, tests, runner.RunnerConfig{
 			Include:           includeRE,
 			Exclude:           excludeRE,
 			ShowTime:          showTime,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,7 +64,7 @@ var runCmd = &cobra.Command{
 		out := output.NewOutput(wantedOutput, os.Stdout)
 		_ = out.Println("%s", out.Message("** Starting tests!"))
 
-		currentRun, err := runner.Run(tests, runner.Config{
+		currentRun, err := runner.Run(cfg, tests, runner.Config{
 			Include:           includeRE,
 			Exclude:           excludeRE,
 			ShowTime:          showTime,

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,6 @@ func NewConfigFromFile(cfgFile string) (*FTWConfiguration, error) {
 
 // NewConfigFromEnv reads configuration information from environment variables that start with `FTW_`
 func NewConfigFromEnv() (*FTWConfiguration, error) {
-	// koanf merges by default, but we never want to merge in this case
 	var err error
 	var k = koanf.New(".")
 	cfg := NewDefaultConfig()
@@ -103,7 +102,6 @@ func NewConfigFromEnv() (*FTWConfiguration, error) {
 
 // NewConfigFromString initializes the configuration from a yaml formatted string. Useful for testing.
 func NewConfigFromString(conf string) (*FTWConfiguration, error) {
-	// koanf merges by default, but we never want to merge in this case
 	var k = koanf.New(".")
 	var err error
 	cfg := NewDefaultConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -118,3 +118,20 @@ func NewConfigFromString(conf string) (*FTWConfiguration, error) {
 
 	return cfg, err
 }
+
+// WithLogfile changes the logfile in the configuration.
+func (c *FTWConfiguration) WithLogfile(logfile string) {
+	c.LogFile = logfile
+}
+
+func (c *FTWConfiguration) WithOverrides(overrides FTWTestOverride) {
+	c.TestOverride = overrides
+}
+
+func (c *FTWConfiguration) WithRunMode(runmode RunMode) {
+	c.RunMode = runmode
+}
+
+func (c *FTWConfiguration) WithLogMarkerHeaderName(name string) {
+	c.LogMarkerHeaderName = name
+}

--- a/config/config.go
+++ b/config/config.go
@@ -122,14 +122,17 @@ func (c *FTWConfiguration) WithLogfile(logfile string) {
 	c.LogFile = logfile
 }
 
+// WithOverrides sets the overrides in the configuration.
 func (c *FTWConfiguration) WithOverrides(overrides FTWTestOverride) {
 	c.TestOverride = overrides
 }
 
-func (c *FTWConfiguration) WithRunMode(runmode RunMode) {
-	c.RunMode = runmode
+// WithRunMode sets the RunMode.
+func (c *FTWConfiguration) WithRunMode(runMode RunMode) {
+	c.RunMode = runMode
 }
 
+// WithLogMarkerHeaderName sets the new LogMarker header name.
 func (c *FTWConfiguration) WithLogMarkerHeaderName(name string) {
 	c.LogMarkerHeaderName = name
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,9 +175,6 @@ func TestNewConfigFromFileRunMode(t *testing.T) {
 
 func TestNewDefaultConfigWithParams(t *testing.T) {
 	cfg := NewDefaultConfig()
-	assert.Equal(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName)
-	assert.Equal(t, DefaultRunMode, cfg.RunMode)
-	assert.Equal(t, "", cfg.LogFile)
 	cfg.WithLogfile("mylogfile.log")
 	assert.Equal(t, "mylogfile.log", cfg.LogFile)
 	overrides := FTWTestOverride{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,14 +1,15 @@
 package config
 
 import (
-    "github.com/coreruleset/go-ftw/test"
-    "os"
-    "regexp"
-    "testing"
+	"os"
+	"regexp"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/coreruleset/go-ftw/test"
 
-    "github.com/coreruleset/go-ftw/utils"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coreruleset/go-ftw/utils"
 )
 
 var yamlConfig = `---
@@ -36,138 +37,159 @@ var jsonConfig = `
 `
 
 func TestNewConfig(t *testing.T) {
-    overrides := FTWTestOverride{
-        Input:     test.Input{},
-        Ignore:    nil,
-        ForcePass: nil,
-        ForceFail: nil,
-    }
-    cfg := NewConfig("mylogfile.log", overrides, "X-Test-Me", "cloud")
-    assert.Equal(t, "mylogfile.log", cfg.LogFile)
-    assert.Equal(t, "X-Test-Me", cfg.LogMarkerHeaderName)
-    assert.Equal(t, CloudRunMode, cfg.RunMode)
+	overrides := FTWTestOverride{
+		Input:     test.Input{},
+		Ignore:    nil,
+		ForcePass: nil,
+		ForceFail: nil,
+	}
+	cfg := NewConfig("mylogfile.log", overrides, "X-Test-Me", "cloud")
+	assert.Equal(t, "mylogfile.log", cfg.LogFile)
+	assert.Equal(t, "X-Test-Me", cfg.LogMarkerHeaderName)
+	assert.Equal(t, CloudRunMode, cfg.RunMode)
 }
 
 func TestNewDefaultConfig(t *testing.T) {
-    cfg := NewDefaultConfig()
-    assert.Equal(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName)
-    assert.Equal(t, DefaultRunMode, cfg.RunMode)
-    assert.Equal(t, "", cfg.LogFile)
+	cfg := NewDefaultConfig()
+	assert.Equal(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName)
+	assert.Equal(t, DefaultRunMode, cfg.RunMode)
+	assert.Equal(t, "", cfg.LogFile)
 }
 
 func TestNewConfigBadFileConfig(t *testing.T) {
-    filename, _ := utils.CreateTempFileWithContent(jsonConfig, "test-*.yaml")
-    defer os.Remove(filename)
-    cfg, err := NewConfigFromFile(filename)
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
+	filename, _ := utils.CreateTempFileWithContent(jsonConfig, "test-*.yaml")
+	defer os.Remove(filename)
+	cfg, err := NewConfigFromFile(filename)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 }
 
 func TestNewConfigConfig(t *testing.T) {
-    filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
+	filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
 
-    cfg, err := NewConfigFromFile(filename)
+	cfg, err := NewConfigFromFile(filename)
 
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
-    assert.NotEmpty(t, cfg.TestOverride.Input, "Ignore list must not be empty")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.NotEmpty(t, cfg.TestOverride.Input, "Ignore list must not be empty")
 
-    for id, text := range cfg.TestOverride.Ignore {
-        assert.Contains(t, (*regexp.Regexp)(id).String(), "920400-1$", "Looks like we could not find item to ignore")
-        assert.Equal(t, "This test must be ignored", text, "Text doesn't match")
-    }
+	for id, text := range cfg.TestOverride.Ignore {
+		assert.Contains(t, (*regexp.Regexp)(id).String(), "920400-1$", "Looks like we could not find item to ignore")
+		assert.Equal(t, "This test must be ignored", text, "Text doesn't match")
+	}
 
-    overrides := cfg.TestOverride.Input
-    assert.NotNil(t, overrides.DestAddr, "Looks like we are not overriding destination address")
-    assert.Equal(t, "httpbin.org", *overrides.DestAddr, "Looks like we are not overriding destination address")
+	overrides := cfg.TestOverride.Input
+	assert.NotNil(t, overrides.DestAddr, "Looks like we are not overriding destination address")
+	assert.Equal(t, "httpbin.org", *overrides.DestAddr, "Looks like we are not overriding destination address")
 }
 
 func TestNewConfigBadConfig(t *testing.T) {
-    filename, _ := utils.CreateTempFileWithContent(yamlBadConfig, "test-*.yaml")
-    defer os.Remove(filename)
-    cfg, err := NewConfigFromFile(filename)
+	filename, _ := utils.CreateTempFileWithContent(yamlBadConfig, "test-*.yaml")
+	defer os.Remove(filename)
+	cfg, err := NewConfigFromFile(filename)
 
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 }
 
 func TestNewConfigDefaultConfig(t *testing.T) {
-    // For this test we need a local .ftw.yaml file
-    fileName := ".ftw.yaml"
-    _ = os.WriteFile(fileName, []byte(yamlConfig), 0644)
-    t.Cleanup(func() {
-        os.Remove(fileName)
-    })
+	// For this test we need a local .ftw.yaml file
+	fileName := ".ftw.yaml"
+	_ = os.WriteFile(fileName, []byte(yamlConfig), 0644)
+	t.Cleanup(func() {
+		os.Remove(fileName)
+	})
 
-    cfg, err := NewConfigFromFile("")
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
+	cfg, err := NewConfigFromFile("")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 }
 
 func TestNewConfigFromString(t *testing.T) {
-    cfg, err := NewConfigFromString(yamlConfig)
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
+	cfg, err := NewConfigFromString(yamlConfig)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 }
 
 func TestNewEnvConfigFromString(t *testing.T) {
-    cfg, err := NewConfigFromString(yamlConfig)
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
+	cfg, err := NewConfigFromString(yamlConfig)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 }
 
 func TestNewConfigFromEnv(t *testing.T) {
-    // Set some environment so it gets merged with conf
-    os.Setenv("FTW_LOGFILE", "koanf")
+	// Set some environment so it gets merged with conf
+	os.Setenv("FTW_LOGFILE", "koanf")
 
-    cfg, err := NewConfigFromEnv()
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
-    assert.Equal(t, "koanf", cfg.LogFile)
+	cfg, err := NewConfigFromEnv()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, "koanf", cfg.LogFile)
 }
 
 func TestNewConfigFromEnvHasDefaults(t *testing.T) {
-    cfg, err := NewConfigFromEnv()
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
+	cfg, err := NewConfigFromEnv()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
-    assert.Equalf(t, DefaultRunMode, cfg.RunMode,
-        "unexpected default value '%s' for run mode", cfg.RunMode)
-    assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
-        "unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
+	assert.Equalf(t, DefaultRunMode, cfg.RunMode,
+		"unexpected default value '%s' for run mode", cfg.RunMode)
+	assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
+		"unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
 
 }
 
 func TestNewConfigFromFileHasDefaults(t *testing.T) {
-    filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
-    defer os.Remove(filename)
+	filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
+	defer os.Remove(filename)
 
-    cfg, err := NewConfigFromFile(filename)
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
-    assert.Equalf(t, DefaultRunMode, cfg.RunMode,
-        "unexpected default value '%s' for run mode", cfg.RunMode)
-    assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
-        "unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
+	cfg, err := NewConfigFromFile(filename)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equalf(t, DefaultRunMode, cfg.RunMode,
+		"unexpected default value '%s' for run mode", cfg.RunMode)
+	assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
+		"unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
 }
 
 func TestNewConfigFromStringHasDefaults(t *testing.T) {
-    cfg, err := NewConfigFromString("")
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
-    assert.Equalf(t, DefaultRunMode, cfg.RunMode,
-        "unexpected default value '%s' for run mode", cfg.RunMode)
-    assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
-        "unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
+	cfg, err := NewConfigFromString("")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equalf(t, DefaultRunMode, cfg.RunMode,
+		"unexpected default value '%s' for run mode", cfg.RunMode)
+	assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
+		"unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
 }
 
 func TestNewConfigFromFileRunMode(t *testing.T) {
-    filename, _ := utils.CreateTempFileWithContent(yamlCloudConfig, "test-*.yaml")
-    defer os.Remove(filename)
+	filename, _ := utils.CreateTempFileWithContent(yamlCloudConfig, "test-*.yaml")
+	defer os.Remove(filename)
 
-    cfg, err := NewConfigFromFile(filename)
-    assert.NoError(t, err)
-    assert.NotNil(t, cfg)
-    assert.Equalf(t, CloudRunMode, cfg.RunMode,
-        "unexpected value '%s' for run mode, expected '%s;", cfg.RunMode, CloudRunMode)
+	cfg, err := NewConfigFromFile(filename)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equalf(t, CloudRunMode, cfg.RunMode,
+		"unexpected value '%s' for run mode, expected '%s;", cfg.RunMode, CloudRunMode)
+}
+
+func TestNewDefaultConfigWithParams(t *testing.T) {
+	cfg := NewDefaultConfig()
+	assert.Equal(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName)
+	assert.Equal(t, DefaultRunMode, cfg.RunMode)
+	assert.Equal(t, "", cfg.LogFile)
+	cfg.WithLogfile("mylogfile.log")
+	assert.Equal(t, "mylogfile.log", cfg.LogFile)
+	overrides := FTWTestOverride{
+		Input:     test.Input{},
+		Ignore:    nil,
+		ForcePass: nil,
+		ForceFail: nil,
+	}
+	cfg.WithOverrides(overrides)
+	assert.Equal(t, overrides, cfg.TestOverride)
+	cfg.WithLogMarkerHeaderName("NEW-MARKER-TEST")
+	assert.Equal(t, "NEW-MARKER-TEST", cfg.LogMarkerHeaderName)
+	cfg.WithRunMode(CloudRunMode)
+	assert.Equal(t, CloudRunMode, cfg.RunMode)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"os"
-	"regexp"
-	"testing"
+    "github.com/coreruleset/go-ftw/test"
+    "os"
+    "regexp"
+    "testing"
 
-	"github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/assert"
 
-	"github.com/coreruleset/go-ftw/utils"
+    "github.com/coreruleset/go-ftw/utils"
 )
 
 var yamlConfig = `---
@@ -34,113 +35,139 @@ var jsonConfig = `
 {"test": "type"}
 `
 
+func TestNewConfig(t *testing.T) {
+    overrides := FTWTestOverride{
+        Input:     test.Input{},
+        Ignore:    nil,
+        ForcePass: nil,
+        ForceFail: nil,
+    }
+    cfg := NewConfig("mylogfile.log", overrides, "X-Test-Me", "cloud")
+    assert.Equal(t, "mylogfile.log", cfg.LogFile)
+    assert.Equal(t, "X-Test-Me", cfg.LogMarkerHeaderName)
+    assert.Equal(t, CloudRunMode, cfg.RunMode)
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+    cfg := NewDefaultConfig()
+    assert.Equal(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName)
+    assert.Equal(t, DefaultRunMode, cfg.RunMode)
+    assert.Equal(t, "", cfg.LogFile)
+}
+
 func TestNewConfigBadFileConfig(t *testing.T) {
-	filename, _ := utils.CreateTempFileWithContent(jsonConfig, "test-*.yaml")
-	defer os.Remove(filename)
-	err := NewConfigFromFile(filename)
-	assert.NoError(t, err)
+    filename, _ := utils.CreateTempFileWithContent(jsonConfig, "test-*.yaml")
+    defer os.Remove(filename)
+    cfg, err := NewConfigFromFile(filename)
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
 }
 
 func TestNewConfigConfig(t *testing.T) {
-	filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
+    filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
 
-	err := NewConfigFromFile(filename)
+    cfg, err := NewConfigFromFile(filename)
 
-	assert.NoError(t, err)
-	assert.NotEmpty(t, FTWConfig.TestOverride.Input, "Ignore list must not be empty")
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
+    assert.NotEmpty(t, cfg.TestOverride.Input, "Ignore list must not be empty")
 
-	for id, text := range FTWConfig.TestOverride.Ignore {
-		assert.Contains(t, (*regexp.Regexp)(id).String(), "920400-1$", "Looks like we could not find item to ignore")
-		assert.Equal(t, "This test must be ignored", text, "Text doesn't match")
-	}
+    for id, text := range cfg.TestOverride.Ignore {
+        assert.Contains(t, (*regexp.Regexp)(id).String(), "920400-1$", "Looks like we could not find item to ignore")
+        assert.Equal(t, "This test must be ignored", text, "Text doesn't match")
+    }
 
-	overrides := FTWConfig.TestOverride.Input
-	assert.NotNil(t, overrides.DestAddr, "Looks like we are not overriding destination address")
-	assert.Equal(t, "httpbin.org", *overrides.DestAddr, "Looks like we are not overriding destination address")
+    overrides := cfg.TestOverride.Input
+    assert.NotNil(t, overrides.DestAddr, "Looks like we are not overriding destination address")
+    assert.Equal(t, "httpbin.org", *overrides.DestAddr, "Looks like we are not overriding destination address")
 }
 
 func TestNewConfigBadConfig(t *testing.T) {
-	filename, _ := utils.CreateTempFileWithContent(yamlBadConfig, "test-*.yaml")
-	defer os.Remove(filename)
-	_ = NewConfigFromFile(filename)
+    filename, _ := utils.CreateTempFileWithContent(yamlBadConfig, "test-*.yaml")
+    defer os.Remove(filename)
+    cfg, err := NewConfigFromFile(filename)
 
-	assert.NotNil(t, FTWConfig)
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
 }
 
 func TestNewConfigDefaultConfig(t *testing.T) {
-	// For this test we need a local .ftw.yaml file
-	fileName := ".ftw.yaml"
-	_ = os.WriteFile(fileName, []byte(yamlConfig), 0644)
-	t.Cleanup(func() {
-		os.Remove(fileName)
-	})
+    // For this test we need a local .ftw.yaml file
+    fileName := ".ftw.yaml"
+    _ = os.WriteFile(fileName, []byte(yamlConfig), 0644)
+    t.Cleanup(func() {
+        os.Remove(fileName)
+    })
 
-	_ = NewConfigFromFile("")
-
-	assert.NotNil(t, FTWConfig)
+    cfg, err := NewConfigFromFile("")
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
 }
 
 func TestNewConfigFromString(t *testing.T) {
-	err := NewConfigFromString(yamlConfig)
-	assert.NoError(t, err)
+    cfg, err := NewConfigFromString(yamlConfig)
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
 }
 
 func TestNewEnvConfigFromString(t *testing.T) {
-	err := NewConfigFromString(yamlConfig)
-	assert.NoError(t, err)
+    cfg, err := NewConfigFromString(yamlConfig)
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
 }
 
 func TestNewConfigFromEnv(t *testing.T) {
-	// Set some environment so it gets merged with conf
-	os.Setenv("FTW_LOGFILE", "koanf")
+    // Set some environment so it gets merged with conf
+    os.Setenv("FTW_LOGFILE", "koanf")
 
-	err := NewConfigFromEnv()
-	assert.NoError(t, err)
-
-	assert.Equal(t, "koanf", FTWConfig.LogFile)
+    cfg, err := NewConfigFromEnv()
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
+    assert.Equal(t, "koanf", cfg.LogFile)
 }
 
 func TestNewConfigFromEnvHasDefaults(t *testing.T) {
-	err := NewConfigFromEnv()
-	assert.NoError(t, err)
+    cfg, err := NewConfigFromEnv()
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
 
-	assert.Equalf(t, DefaultRunMode, FTWConfig.RunMode,
-		"unexpected default value '%s' for run mode", FTWConfig.RunMode)
-	assert.Equalf(t, DefaultLogMarkerHeaderName, FTWConfig.LogMarkerHeaderName,
-		"unexpected default value '%s' for logmarkerheadername", FTWConfig.LogMarkerHeaderName)
+    assert.Equalf(t, DefaultRunMode, cfg.RunMode,
+        "unexpected default value '%s' for run mode", cfg.RunMode)
+    assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
+        "unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
 
 }
 
 func TestNewConfigFromFileHasDefaults(t *testing.T) {
-	filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
-	defer os.Remove(filename)
+    filename, _ := utils.CreateTempFileWithContent(yamlConfig, "test-*.yaml")
+    defer os.Remove(filename)
 
-	err := NewConfigFromFile(filename)
-	assert.NoError(t, err)
-
-	assert.Equalf(t, DefaultRunMode, FTWConfig.RunMode,
-		"unexpected default value '%s' for run mode", FTWConfig.RunMode)
-	assert.Equalf(t, DefaultLogMarkerHeaderName, FTWConfig.LogMarkerHeaderName,
-		"unexpected default value '%s' for logmarkerheadername", FTWConfig.LogMarkerHeaderName)
+    cfg, err := NewConfigFromFile(filename)
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
+    assert.Equalf(t, DefaultRunMode, cfg.RunMode,
+        "unexpected default value '%s' for run mode", cfg.RunMode)
+    assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
+        "unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
 }
 
 func TestNewConfigFromStringHasDefaults(t *testing.T) {
-	err := NewConfigFromString("")
-	assert.NoError(t, err)
-
-	assert.Equalf(t, DefaultRunMode, FTWConfig.RunMode,
-		"unexpected default value '%s' for run mode", FTWConfig.RunMode)
-	assert.Equalf(t, DefaultLogMarkerHeaderName, FTWConfig.LogMarkerHeaderName,
-		"unexpected default value '%s' for logmarkerheadername", FTWConfig.LogMarkerHeaderName)
+    cfg, err := NewConfigFromString("")
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
+    assert.Equalf(t, DefaultRunMode, cfg.RunMode,
+        "unexpected default value '%s' for run mode", cfg.RunMode)
+    assert.Equalf(t, DefaultLogMarkerHeaderName, cfg.LogMarkerHeaderName,
+        "unexpected default value '%s' for logmarkerheadername", cfg.LogMarkerHeaderName)
 }
 
 func TestNewConfigFromFileRunMode(t *testing.T) {
-	filename, _ := utils.CreateTempFileWithContent(yamlCloudConfig, "test-*.yaml")
-	defer os.Remove(filename)
+    filename, _ := utils.CreateTempFileWithContent(yamlCloudConfig, "test-*.yaml")
+    defer os.Remove(filename)
 
-	err := NewConfigFromFile(filename)
-	assert.NoError(t, err)
-
-	assert.Equalf(t, CloudRunMode, FTWConfig.RunMode,
-		"unexpected value '%s' for run mode, expected '%s;", FTWConfig.RunMode, CloudRunMode)
+    cfg, err := NewConfigFromFile(filename)
+    assert.NoError(t, err)
+    assert.NotNil(t, cfg)
+    assert.Equalf(t, CloudRunMode, cfg.RunMode,
+        "unexpected value '%s' for run mode, expected '%s;", cfg.RunMode, CloudRunMode)
 }

--- a/config/types.go
+++ b/config/types.go
@@ -19,9 +19,6 @@ const (
 	DefaultLogMarkerHeaderName string = "X-CRS-Test"
 )
 
-// FTWConfig is being exported to be used across the app
-var FTWConfig *FTWConfiguration
-
 // FTWConfiguration FTW global Configuration
 type FTWConfiguration struct {
 	LogFile             string          `koanf:"logfile"`

--- a/runner/run.go
+++ b/runner/run.go
@@ -25,11 +25,9 @@ var errBadTestRequest = errors.New("ftw/run: bad test: choose between data, enco
 func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out *output.Output) (TestRunContext, error) {
 	out.Println("%s", out.Message("** Running go-ftw!"))
 
-	stats := NewRunStats()
-
 	logLines, err := waflog.NewFTWLogLines(cfg)
 	if err != nil {
-		return &TestRunContext{}, err
+		return TestRunContext{}, err
 	}
 
 	conf := ftwhttp.NewClientConfig()
@@ -41,7 +39,7 @@ func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out
 	}
 	client, err := ftwhttp.NewClient(conf)
 	if err != nil {
-		return &TestRunContext{}, err
+		return TestRunContext{}, err
 	}
 	// TODO: These defaults shouldn't be initialized here but config intialization
 	// needs to be cleaned up properly first (e.g., with a `NewConfig()` function)
@@ -77,7 +75,7 @@ func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out
 
 	defer cleanLogs(logLines)
 
-	return &runContext, nil
+	return runContext, nil
 }
 
 // RunTest runs an individual test.

--- a/runner/run.go
+++ b/runner/run.go
@@ -22,12 +22,12 @@ import (
 var errBadTestRequest = errors.New("ftw/run: bad test: choose between data, encoded_request, or raw_request")
 
 // Run runs your tests with the specified Config.
-func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out *output.Output) (TestRunContext, error) {
+func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out *output.Output) (*TestRunContext, error) {
 	out.Println("%s", out.Message("** Running go-ftw!"))
 
 	logLines, err := waflog.NewFTWLogLines(cfg)
 	if err != nil {
-		return TestRunContext{}, err
+		return &TestRunContext{}, err
 	}
 
 	conf := ftwhttp.NewClientConfig()
@@ -39,7 +39,7 @@ func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out
 	}
 	client, err := ftwhttp.NewClient(conf)
 	if err != nil {
-		return TestRunContext{}, err
+		return &TestRunContext{}, err
 	}
 	// TODO: These defaults shouldn't be initialized here but config intialization
 	// needs to be cleaned up properly first (e.g., with a `NewConfig()` function)
@@ -51,7 +51,7 @@ func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out
 	if maxMarkerLogLines == 0 {
 		maxMarkerLogLines = 500
 	}
-	runContext := TestRunContext{
+	runContext := &TestRunContext{
 		Config:            cfg,
 		Include:           c.Include,
 		Exclude:           c.Exclude,
@@ -66,8 +66,8 @@ func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out
 	}
 
 	for _, tc := range tests {
-		if err := RunTest(&runContext, tc); err != nil {
-			return TestRunContext{}, err
+		if err := RunTest(runContext, tc); err != nil {
+			return &TestRunContext{}, err
 		}
 	}
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -21,7 +21,7 @@ import (
 
 var errBadTestRequest = errors.New("ftw/run: bad test: choose between data, encoded_request, or raw_request")
 
-// Run runs your tests with the specified Config. Returns error if some test failed
+// Run runs your tests with the specified Config.
 func Run(cfg *config.FTWConfiguration, tests []test.FTWTest, c RunnerConfig, out *output.Output) (TestRunContext, error) {
 	out.Println("%s", out.Message("** Running go-ftw!"))
 

--- a/runner/types.go
+++ b/runner/types.go
@@ -11,8 +11,8 @@ import (
 	"github.com/coreruleset/go-ftw/waflog"
 )
 
-// Config provides configuration for the test runner.
-type Config struct {
+// RunnerConfig provides configuration for the test runner.
+type RunnerConfig struct {
 	// Include is a regular expression to filter tests to include. If nil, all tests are included.
 	Include *regexp.Regexp
 	// Exclude is a regular expression to filter tests to exclude. If nil, no tests are excluded.
@@ -37,6 +37,7 @@ type Config struct {
 // This includes configuration information as well as statistics
 // and results.
 type TestRunContext struct {
+	Config            *config.FTWConfiguration
 	Include           *regexp.Regexp
 	Exclude           *regexp.Regexp
 	ShowTime          bool
@@ -49,5 +50,4 @@ type TestRunContext struct {
 	Duration          time.Duration
 	Client            *ftwhttp.Client
 	LogLines          *waflog.FTWLogLines
-	RunMode           config.RunMode
 }

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -4,13 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"os"
 	"regexp"
 
 	"github.com/icza/backscanner"
 	"github.com/rs/zerolog/log"
-
-	"github.com/coreruleset/go-ftw/config"
 )
 
 // Contains looks in logfile for regex
@@ -84,7 +81,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 // stageID is the ID of the current stage, which is part of the marker line
 // readLimit is the maximum numbers of lines to check
 func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit int) []byte {
-	offset, err := ll.logFile.Seek(0, os.SEEK_END)
+	offset, err := ll.logFile.Seek(0, io.SeekEnd)
 	if err != nil {
 		log.Error().Caller().Err(err).Msgf("failed to seek end of log file")
 		return nil
@@ -96,7 +93,7 @@ func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit int) []byte {
 	}
 	scanner := backscanner.NewOptions(ll.logFile, int(offset), backscannerOptions)
 	stageIDBytes := []byte(stageID)
-	crsHeaderBytes := bytes.ToLower([]byte(config.FTWConfig.LogMarkerHeaderName))
+	crsHeaderBytes := bytes.ToLower([]byte(ll.cfg.LogMarkerHeaderName))
 
 	var line []byte
 	lineCounter := 0

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -35,10 +35,6 @@ func (ll *FTWLogLines) Contains(match string) bool {
 func (ll *FTWLogLines) getMarkedLines() [][]byte {
 	var found [][]byte
 
-	if err := ll.openLogFile(); err != nil {
-		log.Error().Caller().Msgf("cannot open log file: %s", err)
-	}
-
 	fi, err := ll.logFile.Stat()
 	if err != nil {
 		log.Error().Caller().Msgf("cannot read file's size")
@@ -93,7 +89,7 @@ func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit int) []byte {
 	}
 	scanner := backscanner.NewOptions(ll.logFile, int(offset), backscannerOptions)
 	stageIDBytes := []byte(stageID)
-	crsHeaderBytes := bytes.ToLower([]byte(ll.cfg.LogMarkerHeaderName))
+	crsHeaderBytes := bytes.ToLower([]byte(ll.LogMarkerHeaderName))
 
 	var line []byte
 	lineCounter := 0

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLine := "X-cRs-TeSt: " + stageID
@@ -28,7 +29,7 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
@@ -39,8 +40,9 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 }
 
 func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLine := "X-cRs-TeSt: " + stageID
@@ -52,7 +54,7 @@ func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
@@ -65,8 +67,9 @@ func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
 }
 
 func TestReadGetMarkedLines(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	startMarkerLine := "X-cRs-TeSt: " + stageID + " -start"
@@ -79,7 +82,7 @@ func TestReadGetMarkedLines(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll, err := NewFTWLogLines(
@@ -102,8 +105,9 @@ func TestReadGetMarkedLines(t *testing.T) {
 }
 
 func TestReadGetMarkedLinesWithTrailingEmptyLines(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	startMarkerLine := "X-cRs-TeSt: " + stageID + " -start"
@@ -116,7 +120,7 @@ func TestReadGetMarkedLinesWithTrailingEmptyLines(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll, err := NewFTWLogLines(
@@ -139,8 +143,9 @@ func TestReadGetMarkedLinesWithTrailingEmptyLines(t *testing.T) {
 }
 
 func TestReadGetMarkedLinesWithPrecedingLines(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	startMarkerLine := "X-cRs-TeSt: " + stageID + " -start"
@@ -156,7 +161,7 @@ func TestReadGetMarkedLinesWithPrecedingLines(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll, err := NewFTWLogLines(
@@ -179,8 +184,9 @@ func TestReadGetMarkedLinesWithPrecedingLines(t *testing.T) {
 }
 
 func TestFTWLogLines_Contains(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLine := "X-cRs-TeSt: " + stageID
@@ -192,7 +198,7 @@ func TestFTWLogLines_Contains(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	log, err := os.Open(filename)
 	assert.NoError(t, err)
 
@@ -240,8 +246,8 @@ func TestFTWLogLines_Contains(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ll := &FTWLogLines{
+				cfg:         cfg,
 				logFile:     tt.fields.logFile,
-				FileName:    tt.fields.FileName,
 				StartMarker: bytes.ToLower(tt.fields.StartMarker),
 				EndMarker:   bytes.ToLower(tt.fields.EndMarker),
 			}
@@ -252,8 +258,9 @@ func TestFTWLogLines_Contains(t *testing.T) {
 }
 
 func TestFTWLogLines_ContainsIn404(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLine := fmt.Sprint(`[2022-11-12 23:08:18.012572] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
@@ -266,7 +273,7 @@ func TestFTWLogLines_ContainsIn404(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	log, err := os.Open(filename)
 	assert.NoError(t, err)
 
@@ -306,8 +313,8 @@ func TestFTWLogLines_ContainsIn404(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ll := &FTWLogLines{
+				cfg:         cfg,
 				logFile:     tt.fields.logFile,
-				FileName:    tt.fields.FileName,
 				StartMarker: bytes.ToLower(tt.fields.StartMarker),
 				EndMarker:   bytes.ToLower(tt.fields.EndMarker),
 			}
@@ -318,8 +325,9 @@ func TestFTWLogLines_ContainsIn404(t *testing.T) {
 }
 
 func TestFTWLogLines_CheckForLogMarkerIn404(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLine := fmt.Sprint(`[2022-11-12 23:08:18.012572] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
@@ -332,15 +340,15 @@ func TestFTWLogLines_CheckForLogMarkerIn404(t *testing.T) {
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	assert.NoError(t, err)
 
-	config.FTWConfig.LogFile = filename
+	cfg.LogFile = filename
 	log, err := os.Open(filename)
 	assert.NoError(t, err)
 
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll := &FTWLogLines{
+		cfg:         cfg,
 		logFile:     log,
-		FileName:    filename,
 		StartMarker: bytes.ToLower([]byte(markerLine)),
 		EndMarker:   bytes.ToLower([]byte(markerLine)),
 	}

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -32,9 +32,9 @@ func TestReadCheckLogForMarkerNoMarkerAtEnd(t *testing.T) {
 	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
+	ll, err := NewFTWLogLines(cfg)
 	assert.NoError(t, err)
-
+	ll.WithStartMarker([]byte(markerLine))
 	marker := ll.CheckLogForMarker(stageID, 100)
 	assert.Equal(t, string(marker), strings.ToLower(markerLine), "unexpectedly found marker")
 }
@@ -57,7 +57,8 @@ func TestReadCheckLogForMarkerWithMarkerAtEnd(t *testing.T) {
 	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(WithStartMarker([]byte(markerLine)))
+	ll, err := NewFTWLogLines(cfg)
+	ll.WithStartMarker([]byte(markerLine))
 	assert.NoError(t, err)
 
 	marker := ll.CheckLogForMarker(stageID, 100)
@@ -85,10 +86,10 @@ func TestReadGetMarkedLines(t *testing.T) {
 	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(
-		WithStartMarker(bytes.ToLower([]byte(startMarkerLine))),
-		WithEndMarker(bytes.ToLower([]byte(endMarkerLine))))
+	ll, err := NewFTWLogLines(cfg)
 	assert.NoError(t, err)
+	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
+	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
 
 	foundLines := ll.getMarkedLines()
 	// logs are scanned backwards
@@ -123,10 +124,10 @@ func TestReadGetMarkedLinesWithTrailingEmptyLines(t *testing.T) {
 	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(
-		WithStartMarker(bytes.ToLower([]byte(startMarkerLine))),
-		WithEndMarker(bytes.ToLower([]byte(endMarkerLine))))
+	ll, err := NewFTWLogLines(cfg)
 	assert.NoError(t, err)
+	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
+	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
 
 	foundLines := ll.getMarkedLines()
 	// logs are scanned backwards
@@ -164,10 +165,10 @@ func TestReadGetMarkedLinesWithPrecedingLines(t *testing.T) {
 	cfg.LogFile = filename
 	t.Cleanup(func() { os.Remove(filename) })
 
-	ll, err := NewFTWLogLines(
-		WithStartMarker(bytes.ToLower([]byte(startMarkerLine))),
-		WithEndMarker(bytes.ToLower([]byte(endMarkerLine))))
+	ll, err := NewFTWLogLines(cfg)
 	assert.NoError(t, err)
+	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
+	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
 
 	foundLines := ll.getMarkedLines()
 	// logs are scanned backwards
@@ -205,16 +206,16 @@ func TestFTWLogLines_Contains(t *testing.T) {
 	t.Cleanup(func() { os.Remove(filename) })
 
 	type fields struct {
-		logFile     *os.File
-		FileName    string
-		StartMarker []byte
-		EndMarker   []byte
+		logFile             *os.File
+		LogMarkerHeaderName []byte
+		StartMarker         []byte
+		EndMarker           []byte
 	}
 	f := fields{
-		logFile:     log,
-		FileName:    filename,
-		StartMarker: []byte(markerLine),
-		EndMarker:   []byte(markerLine),
+		logFile:             log,
+		LogMarkerHeaderName: []byte(cfg.LogMarkerHeaderName),
+		StartMarker:         []byte(markerLine),
+		EndMarker:           []byte(markerLine),
 	}
 
 	type args struct {
@@ -246,10 +247,10 @@ func TestFTWLogLines_Contains(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ll := &FTWLogLines{
-				cfg:         cfg,
-				logFile:     tt.fields.logFile,
-				StartMarker: bytes.ToLower(tt.fields.StartMarker),
-				EndMarker:   bytes.ToLower(tt.fields.EndMarker),
+				logFile:             tt.fields.logFile,
+				LogMarkerHeaderName: bytes.ToLower(tt.fields.LogMarkerHeaderName),
+				StartMarker:         bytes.ToLower(tt.fields.StartMarker),
+				EndMarker:           bytes.ToLower(tt.fields.EndMarker),
 			}
 			got := ll.Contains(tt.args.match)
 			assert.Equalf(t, tt.want, got, "Contains() = %v, want %v", got, tt.want)
@@ -280,16 +281,16 @@ func TestFTWLogLines_ContainsIn404(t *testing.T) {
 	t.Cleanup(func() { os.Remove(filename) })
 
 	type fields struct {
-		logFile     *os.File
-		FileName    string
-		StartMarker []byte
-		EndMarker   []byte
+		logFile             *os.File
+		LogMarkerHeaderName []byte
+		StartMarker         []byte
+		EndMarker           []byte
 	}
 	f := fields{
-		logFile:     log,
-		FileName:    filename,
-		StartMarker: []byte(markerLine),
-		EndMarker:   []byte(markerLine),
+		logFile:             log,
+		LogMarkerHeaderName: []byte(cfg.LogMarkerHeaderName),
+		StartMarker:         []byte(markerLine),
+		EndMarker:           []byte(markerLine),
 	}
 
 	type args struct {
@@ -313,10 +314,10 @@ func TestFTWLogLines_ContainsIn404(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ll := &FTWLogLines{
-				cfg:         cfg,
-				logFile:     tt.fields.logFile,
-				StartMarker: bytes.ToLower(tt.fields.StartMarker),
-				EndMarker:   bytes.ToLower(tt.fields.EndMarker),
+				logFile:             tt.fields.logFile,
+				LogMarkerHeaderName: bytes.ToLower(tt.fields.LogMarkerHeaderName),
+				StartMarker:         bytes.ToLower(tt.fields.StartMarker),
+				EndMarker:           bytes.ToLower(tt.fields.EndMarker),
 			}
 			got := ll.Contains(tt.args.match)
 			assert.Equalf(t, tt.want, got, "Contains() = %v, want %v", got, tt.want)
@@ -347,10 +348,10 @@ func TestFTWLogLines_CheckForLogMarkerIn404(t *testing.T) {
 	t.Cleanup(func() { os.Remove(filename) })
 
 	ll := &FTWLogLines{
-		cfg:         cfg,
-		logFile:     log,
-		StartMarker: bytes.ToLower([]byte(markerLine)),
-		EndMarker:   bytes.ToLower([]byte(markerLine)),
+		logFile:             log,
+		LogMarkerHeaderName: bytes.ToLower([]byte(cfg.LogMarkerHeaderName)),
+		StartMarker:         bytes.ToLower([]byte(markerLine)),
+		EndMarker:           bytes.ToLower([]byte(markerLine)),
 	}
 	foundMarker := ll.CheckLogForMarker(stageID, 100)
 	assert.Equal(t, strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))

--- a/waflog/types.go
+++ b/waflog/types.go
@@ -1,12 +1,15 @@
 // Package waflog encapsulates getting logs from a WAF to compare with expected results
 package waflog
 
-import "os"
+import (
+	"github.com/coreruleset/go-ftw/config"
+	"os"
+)
 
 // FTWLogLines represents the filename to search for logs in a certain timespan
 type FTWLogLines struct {
+	cfg         *config.FTWConfiguration
 	logFile     *os.File
-	FileName    string
 	StartMarker []byte
 	EndMarker   []byte
 }

--- a/waflog/types.go
+++ b/waflog/types.go
@@ -2,17 +2,13 @@
 package waflog
 
 import (
-	"github.com/coreruleset/go-ftw/config"
 	"os"
 )
 
 // FTWLogLines represents the filename to search for logs in a certain timespan
 type FTWLogLines struct {
-	cfg         *config.FTWConfiguration
-	logFile     *os.File
-	StartMarker []byte
-	EndMarker   []byte
+	logFile             *os.File
+	LogMarkerHeaderName []byte
+	StartMarker         []byte
+	EndMarker           []byte
 }
-
-// FTWLogOption follows the option pattern for FTWLogLines
-type FTWLogOption func(*FTWLogLines)

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 func TestNewFTWLogLines(t *testing.T) {
-	err := config.NewConfigFromEnv()
+	cfg, err := config.NewConfigFromEnv()
 	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
 
 	// Don't call NewFTWLogLines to avoid opening the file.
 	ll := &FTWLogLines{}
@@ -18,7 +19,6 @@ func TestNewFTWLogLines(t *testing.T) {
 	for _, opt := range []FTWLogOption{
 		WithStartMarker([]byte("#")),
 		WithEndMarker([]byte("#")),
-		WithLogFile("test"),
 	} {
 		// Call the option giving the instantiated
 		// *House as the argument
@@ -26,7 +26,7 @@ func TestNewFTWLogLines(t *testing.T) {
 	}
 	assert.NotNil(t, ll.StartMarker, "Failed! StartMarker must be set")
 	assert.NotNil(t, ll.EndMarker, "Failed! EndMarker must be set")
-	assert.Equal(t, "test", ll.FileName, "Failed! FileName must be set")
+	assert.Equal(t, "test", ll.cfg.LogFile, "Failed! FileName must be set")
 	err = ll.Cleanup()
 	assert.NoError(t, err)
 }

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -9,24 +9,17 @@ import (
 )
 
 func TestNewFTWLogLines(t *testing.T) {
-	cfg, err := config.NewConfigFromEnv()
-	assert.NoError(t, err)
+	cfg := config.NewDefaultConfig()
 	assert.NotNil(t, cfg)
 
 	// Don't call NewFTWLogLines to avoid opening the file.
 	ll := &FTWLogLines{}
 	// Loop through each option
-	for _, opt := range []FTWLogOption{
-		WithStartMarker([]byte("#")),
-		WithEndMarker([]byte("#")),
-	} {
-		// Call the option giving the instantiated
-		// *House as the argument
-		opt(ll)
-	}
+	ll.WithStartMarker([]byte("#"))
+	ll.WithEndMarker([]byte("#"))
+
 	assert.NotNil(t, ll.StartMarker, "Failed! StartMarker must be set")
 	assert.NotNil(t, ll.EndMarker, "Failed! EndMarker must be set")
-	assert.Equal(t, "test", ll.cfg.LogFile, "Failed! FileName must be set")
-	err = ll.Cleanup()
+	err := ll.Cleanup()
 	assert.NoError(t, err)
 }

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -14,7 +14,6 @@ func TestNewFTWLogLines(t *testing.T) {
 
 	// Don't call NewFTWLogLines to avoid opening the file.
 	ll := &FTWLogLines{}
-	// Loop through each option
 	ll.WithStartMarker([]byte("#"))
 	ll.WithEndMarker([]byte("#"))
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Removes global config. Now some methods will receive the extra config parameter.

Partially addresses #108.