### PR TITLE
Properly load config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,11 +54,12 @@ func initConfig() {
 	if trace {
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	}
-	cfg, errFile := config.NewConfigFromFile(cfgFile)
-	if errFile != nil {
+	var err error
+	cfg, err = config.NewConfigFromFile(cfgFile)
+	if err != nil {
 		cfgenv, errEnv := config.NewConfigFromEnv()
 		if errEnv != nil {
-			log.Fatalf("cannot read config from file (%s) nor environment (%s).", errFile.Error(), errEnv.Error())
+			log.Fatalf("cannot read config from file (%s) nor environment (%s).", err.Error(), errEnv.Error())
 		}
 		cfg = cfgenv
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,7 +14,7 @@ import (
 	"github.com/coreruleset/go-ftw/test"
 )
 
-// cleanCmd represents the clean command
+// runCmd represents the run command
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run Tests",
@@ -42,7 +42,7 @@ var runCmd = &cobra.Command{
 		}
 		if exclude != "" && include != "" {
 			cmd.SilenceUsage = false
-			return fmt.Errorf("You need to choose one: use --include (%s) or --exclude (%s)", include, exclude)
+			return fmt.Errorf("you need to choose one: use --include (%s) or --exclude (%s)", include, exclude)
 		}
 		if maxMarkerRetries != 0 {
 			cfg.WithMaxMarkerRetries(maxMarkerRetries)


### PR DESCRIPTION
The global variable holding the configuration was shadowed in the method that loades the configuration file. Hence, the configuration file was never applied.