### PR TITLE
chore: fix some messages catalog correspondences

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -27,7 +27,7 @@ type catalog map[string]string
 // this catalog is used to translate text from basic terminals to enhanced ones that support emoji, just
 // because we are fancy. If we are not using a normal output, then just use the key from this map.
 var normalCatalog = catalog{
-	"* Starting tests!":                     ":hammer_and_wrench: Starting tests!",
+	"** Starting tests!":                    ":hammer_and_wrench: Starting tests!",
 	"** Running go-ftw!":                    ":rocket:Running go-ftw!",
 	"=> executing tests in file %s":         ":point_right:executing tests in file %s",
 	"+ passed in %s (RTT %s)":               ":check_mark:passed in %s (RTT %s)",

--- a/runner/stats.go
+++ b/runner/stats.go
@@ -91,17 +91,17 @@ func (stats *RunStats) printSummary(out *output.Output) {
 			out.Println(out.Message("+ run %d total tests in %s"), stats.Run, stats.TotalTime)
 			out.Println(out.Message(">> skipped %d tests"), len(stats.Skipped))
 			if len(stats.Ignored) > 0 {
-				out.Println(out.Message("- ignored %d tests"), len(stats.Ignored))
+				out.Println(out.Message("^ ignored %d tests"), len(stats.Ignored))
 			}
 			if len(stats.ForcedPass) > 0 {
-				out.Println(out.Message("- forced to pass %d tests"), len(stats.ForcedPass))
+				out.Println(out.Message("^ forced to pass %d tests"), len(stats.ForcedPass))
 			}
 			if stats.TotalFailed() == 0 {
 				out.Println(out.Message("\\o/ All tests successful!"))
 			} else {
 				out.Println(out.Message("- %d test(s) failed to run: %+q"), len(stats.Failed), stats.Failed)
 				if len(stats.ForcedFail) > 0 {
-					out.Println(out.Message("-  %d test(s) were forced to fail: %+q"), len(stats.ForcedFail), stats.ForcedFail)
+					out.Println(out.Message("- %d test(s) were forced to fail: %+q"), len(stats.ForcedFail), stats.ForcedFail)
 				}
 			}
 		}


### PR DESCRIPTION
Hello!
I'm experiencing some (graphically) bad outputs running go-ftw on an enhanced terminal. It is about some message keys that are not matching the `normalCatalog` values. Proposing some small changes.

Before:
```

🚀 Running go-ftw!
👉 executing tests in file 911100.yaml
  running 911100-1:
  running 911100-2:
  running 911100-3:
  running 911100-4: ✔ passed in 51.387459ms (RTT 97.476958ms)
  running 911100-5:
  running 911100-6: 💥 failed in 5.2525ms (RTT 52.799084ms)
  running 911100-7: 💥 failed in 5.80375ms (RTT 53.880125ms)
  running 911100-8: 💥 failed in 4.340666ms (RTT 52.446125ms)
  skipping 920250-1 - (enabled: false) in file.
  skipping 920250-2 - (enabled: false) in file.
  skipping 920250-3 - (enabled: false) in file.
  skipping 920360-1 - (enabled: false) in file.
  skipping 920370-1 - (enabled: false) in file.
  skipping 920380-1 - (enabled: false) in file.
  skipping 920390-1 - (enabled: false) in file.
➕ run 4 total tests in 66.784375ms
⏭  skipped 2901 tests

%!(EXTRA int=1)
%!(EXTRA int=2)👎 3 test(s) failed to run: ["911100-6" "911100-7" "911100-8"]

%!(EXTRA int=1, []string=[911100-3])Error: failed 4 tests
exit status 1
```
After:
```
🛠️  Starting tests!
🚀 Running go-ftw!
👉 executing tests in file 911100.yaml
  running 911100-1:
  running 911100-2:
  running 911100-3:
  running 911100-4: ✔ passed in 57.132875ms (RTT 87.648209ms)
  running 911100-5:
  running 911100-6: 💥 failed in 4.97775ms (RTT 52.432875ms)
  running 911100-7: 💥 failed in 6.107459ms (RTT 54.2465ms)
  running 911100-8: 💥 failed in 6.454542ms (RTT 54.272833ms)
  skipping 920250-1 - (enabled: false) in file.
  skipping 920250-2 - (enabled: false) in file.
  skipping 920250-3 - (enabled: false) in file.
  skipping 920360-1 - (enabled: false) in file.
  skipping 920370-1 - (enabled: false) in file.
  skipping 920380-1 - (enabled: false) in file.
  skipping 920390-1 - (enabled: false) in file.
➕ run 4 total tests in 74.672626ms
⏭  skipped 2901 tests
☝  ignored 1 tests
☝  forced to pass 2 tests
👎 3 test(s) failed to run: ["911100-6" "911100-7" "911100-8"]
☝ 1 test(s) were forced to fail: ["911100-3"]
Error: failed 4 tests
exit status 1
```