### PR TITLE
fix: send Content-Length header if there is payload

### DIFF
--- a/ftwhttp/header.go
+++ b/ftwhttp/header.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"sort"
-	"strconv"
 )
 
 const (
@@ -68,16 +67,6 @@ func (h Header) Value(key string) string {
 // Del deletes the value associated with key.
 func (h Header) Del(key string) {
 	delete(h, key)
-}
-
-// AddStandard adds standard headers
-func (h Header) AddStandard(dataSize int) {
-	// For better performance, we always close the connection (unless otherwise)
-	h.Add("Connection", "close")
-	// If there is data, we add the length also
-	if dataSize > 0 {
-		h.Add("Content-Length", strconv.Itoa(dataSize))
-	}
 }
 
 // Write writes a header in wire format.

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -106,8 +106,8 @@ func (r *Request) AddHeader(name string, value string) {
 // AddStandardHeaders does the following:
 //   - adds `Connection` header with `close` value (if not set) to improve performance
 //   - adds `Content-Length` header if payload size > 0 or the request method
-//      permits a body (the spec says that the client SHOULD send `Content-Length`
-//      in that case)
+//     permits a body (the spec says that the client SHOULD send `Content-Length`
+//     in that case)
 func (r *Request) AddStandardHeaders() {
 	r.headers.Add("Connection", "close")
 

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -107,7 +107,6 @@ func (r *Request) AddHeader(name string, value string) {
 func (r *Request) AddStandardHeaders() {
 	r.headers.Add("Connection", "close")
 
-	// If there is data or POST method header, we add the length also
 	if len(r.data) > 0 || r.requestLine.Method == "POST" {
 		r.headers.Add("Content-Length", strconv.Itoa(len(r.data)))
 	}

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -105,7 +105,6 @@ func (r *Request) AddHeader(name string, value string) {
 //
 // This will add Content-Length and the proper Content-Type
 func (r *Request) AddStandardHeaders() {
-	// For better performance, we always close the connection (unless otherwise)
 	r.headers.Add("Connection", "close")
 
 	// If there is data or POST method header, we add the length also

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -14,6 +14,8 @@ import (
 	"github.com/coreruleset/go-ftw/utils"
 )
 
+var methodsWithBodyRegex = regexp.MustCompile(`^POST|PUT|PATCH|DELETE$`)
+
 // ToString converts the request line to string for sending it in the wire
 func (rl RequestLine) ToString() string {
 	return fmt.Sprintf("%s %s %s\r\n", rl.Method, rl.URI, rl.Version)
@@ -114,13 +116,9 @@ func (r *Request) AddStandardHeaders() {
 		r.headers.Add("Connection", "close")
 	}
 
-	if len(r.data) > 0 || methodsWithBodyRegex().MatchString(r.requestLine.Method) {
+	if len(r.data) > 0 || methodsWithBodyRegex.MatchString(r.requestLine.Method) {
 		r.headers.Add("Content-Length", strconv.Itoa(len(r.data)))
 	}
-}
-
-func methodsWithBodyRegex() *regexp.Regexp {
-	return regexp.MustCompile(`^POST|PUT|PATCH|DELETE$`)
 }
 
 // isRaw is a helper that returns true if raw or encoded data

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -113,9 +114,13 @@ func (r *Request) AddStandardHeaders() {
 		r.headers.Add("Connection", "close")
 	}
 
-	if len(r.data) > 0 || r.requestLine.Method == "POST" {
+	if len(r.data) > 0 || methodsWithBodyRegex().MatchString(r.requestLine.Method) {
 		r.headers.Add("Content-Length", strconv.Itoa(len(r.data)))
 	}
+}
+
+func methodsWithBodyRegex() *regexp.Regexp {
+	return regexp.MustCompile(`^POST|PUT|PATCH|DELETE$`)
 }
 
 // isRaw is a helper that returns true if raw or encoded data

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -103,7 +103,11 @@ func (r *Request) AddHeader(name string, value string) {
 
 // AddStandardHeaders adds standard headers to the request, if they don't exist
 //
-// This will add Content-Length and the proper Content-Type
+// AddStandardHeaders does the following:
+//   - adds `Connection` header with `close` value (if not set) to improve performance
+//   - adds `Content-Length` header if payload size > 0 or the request method
+//      permits a body (the spec says that the client SHOULD send `Content-Length`
+//      in that case)
 func (r *Request) AddStandardHeaders() {
 	r.headers.Add("Connection", "close")
 

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -109,7 +109,9 @@ func (r *Request) AddHeader(name string, value string) {
 //     permits a body (the spec says that the client SHOULD send `Content-Length`
 //     in that case)
 func (r *Request) AddStandardHeaders() {
-	r.headers.Add("Connection", "close")
+	if r.headers.Get("Connection") == "" {
+		r.headers.Add("Connection", "close")
+	}
 
 	if len(r.data) > 0 || r.requestLine.Method == "POST" {
 		r.headers.Add("Content-Length", strconv.Itoa(len(r.data)))

--- a/ftwhttp/request_test.go
+++ b/ftwhttp/request_test.go
@@ -158,8 +158,6 @@ func TestRequestHeadersSet(t *testing.T) {
 	req.AddHeader("X-New-Header2", "Value")
 	head := req.Headers()
 	assert.Equal(t, "Value", head.Get("X-New-Header2"))
-
-	req.AddStandardHeaders(5)
 }
 
 func TestRequestAutoCompleteHeaders(t *testing.T) {

--- a/ftwhttp/request_test.go
+++ b/ftwhttp/request_test.go
@@ -23,6 +23,62 @@ func generateBaseRequestForTesting() *Request {
 	return req
 }
 
+func TestAddStandardHeadersWhenConnectionHeaderIsPresent(t *testing.T) {
+	req := NewRequest(&RequestLine{}, Header{"Connection": "Not-Closed"}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Connection"), "Not-Closed")
+}
+
+func TestAddStandardHeadersWhenConnectionHeaderIsEmpty(t *testing.T) {
+	req := NewRequest(&RequestLine{}, Header{}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Connection"), "close")
+}
+
+func TestAddStandardHeadersWhenNoData(t *testing.T) {
+	req := NewRequest(&RequestLine{}, Header{}, []byte(""), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Content-Length"), "")
+}
+
+func TestAddStandardHeadersWhenPostMethod(t *testing.T) {
+	req := NewRequest(&RequestLine{Method: "POST"}, Header{}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Content-Length"), "4")
+}
+
+func TestAddStandardHeadersWhenPutMethod(t *testing.T) {
+	req := NewRequest(&RequestLine{Method: "PUT"}, Header{}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Content-Length"), "4")
+}
+
+func TestAddStandardHeadersWhenPatchMethod(t *testing.T) {
+	req := NewRequest(&RequestLine{Method: "PATCH"}, Header{}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Content-Length"), "4")
+}
+
+func TestAddStandardHeadersWhenDeleteMethod(t *testing.T) {
+	req := NewRequest(&RequestLine{Method: "DELETE"}, Header{}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Content-Length"), "4")
+}
+
 func TestMultipartFormDataRequest(t *testing.T) {
 	var req *Request
 

--- a/ftwhttp/request_test.go
+++ b/ftwhttp/request_test.go
@@ -40,11 +40,19 @@ func TestAddStandardHeadersWhenConnectionHeaderIsEmpty(t *testing.T) {
 }
 
 func TestAddStandardHeadersWhenNoData(t *testing.T) {
-	req := NewRequest(&RequestLine{}, Header{}, []byte(""), true)
+	req := NewRequest(&RequestLine{Method: "GET"}, Header{}, []byte(""), true)
 
 	req.AddStandardHeaders()
 
 	assert.Equal(t, req.headers.Get("Content-Length"), "")
+}
+
+func TestAddStandardHeadersWhenGetMethod(t *testing.T) {
+	req := NewRequest(&RequestLine{Method: "GET"}, Header{}, []byte("Data"), true)
+
+	req.AddStandardHeaders()
+
+	assert.Equal(t, req.headers.Get("Content-Length"), "4")
 }
 
 func TestAddStandardHeadersWhenPostMethod(t *testing.T) {


### PR DESCRIPTION
Fixed: https://github.com/coreruleset/go-ftw/issues/134

CRS 942101-* tests received "411 Length Required" data. go-ftw sends Content-Length header if request data is not 0 byte for now.
https://github.com/coreruleset/go-ftw/blob/main/ftwhttp/header.go#L78-L80

I think the Content-Length header needed if request header's method is "POST".