### PR TITLE
fix: checkResult now matches all outputs required in the rule

### DIFF
--- a/check/logs.go
+++ b/check/logs.go
@@ -8,10 +8,26 @@ func (c *FTWCheck) AssertNoLogContains() bool {
 	return false
 }
 
+// NoLogContainsRequired checks that the test requires no_log_contains
+func (c *FTWCheck) NoLogContainsRequired() bool {
+	if c.expected.NoLogContains == "" {
+		return false
+	}
+	return true
+}
+
 // AssertLogContains returns true when the logs contain the string
 func (c *FTWCheck) AssertLogContains() bool {
 	if c.expected.LogContains != "" {
 		return c.log.Contains(c.expected.LogContains)
 	}
 	return false
+}
+
+// LogContainsRequired checks that the test requires log_contains
+func (c *FTWCheck) LogContainsRequired() bool {
+	if c.expected.LogContains == "" {
+		return false
+	}
+	return true
 }

--- a/check/response.go
+++ b/check/response.go
@@ -11,3 +11,11 @@ func (c *FTWCheck) AssertResponseContains(response string) bool {
 	}
 	return false
 }
+
+// ResponseContainsRequired checks that the test requires to check the response
+func (c *FTWCheck) ResponseContainsRequired() bool {
+	if c.expected.ResponseContains == "" {
+		return false
+	}
+	return true
+}

--- a/check/status.go
+++ b/check/status.go
@@ -9,3 +9,11 @@ func (c *FTWCheck) AssertStatus(status int) bool {
 	}
 	return false
 }
+
+// StatusCodeRequired checks that the test requires to check the returned status code
+func (c *FTWCheck) StatusCodeRequired() bool {
+	if c.expected.Status == nil {
+		return false
+	}
+	return true
+}

--- a/runner/run.go
+++ b/runner/run.go
@@ -324,30 +324,30 @@ func checkResult(c *check.FTWCheck, response *ftwhttp.Response, responseError er
 		return Failed
 	}
 	if c.CloudMode() {
-		// Cloud mode assumes that we cannot read logs. So we rely entirely on status code
+		// Cloud mode assumes that we cannot read logs. So we rely entirely on status code and response
 		c.SetCloudMode()
 	}
 
 	// If we didn't expect an error, check the actual response from the waf
 	if response != nil {
-		if c.AssertStatus(response.Parsed.StatusCode) {
-			return Success
+		if c.StatusCodeRequired() && !c.AssertStatus(response.Parsed.StatusCode) {
+			return Failed
 		}
 		// Check response
-		if c.AssertResponseContains(response.GetBodyAsString()) {
-			return Success
+		if c.ResponseContainsRequired() && !c.AssertResponseContains(response.GetBodyAsString()) {
+			return Failed
 		}
 	}
 	// Lastly, check logs
-	if c.AssertLogContains() {
-		return Success
+	if c.LogContainsRequired() && !c.AssertLogContains() {
+		return Failed
 	}
 	// We assume that they were already setup, for comparing
-	if c.AssertNoLogContains() {
-		return Success
+	if c.NoLogContainsRequired() && !c.AssertNoLogContains() {
+		return Failed
 	}
 
-	return Failed
+	return Success
 }
 
 func getRequestFromTest(testRequest test.Input) *ftwhttp.Request {


### PR DESCRIPTION
Hi, I took a quick look at https://github.com/coreruleset/go-ftw/issues/137. As far as I understand, currently `checkResult` as soon as an assertion is true, returns `Success`, considering the rule as passed. This PR proposes to invert the logic, making sure that all the required assertions are not failing.
Not sure about these added `XRequired()` methods, maybe that could be merged into the `XAssert()` methods, but then it does not really become just an "assertion".

Feel free to close it if you have any better implementation in mind!