### PR TITLE
Allow explicit override of Host header.

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -383,6 +383,14 @@ func applyInputOverride(o config.FTWTestOverride, testRequest *test.Input) error
 	if overrides.Port != nil {
 		testRequest.Port = overrides.Port
 	}
+	if overrides.Headers.Get("Host") != "" {
+		if testRequest.Headers == nil {
+			testRequest.Headers = ftwhttp.Header{}
+		}
+		if testRequest.Headers.Get("Host") == "" {
+			testRequest.Headers.Set("Host", overrides.Headers.Get("Host"))
+		}
+	}
 	if overrides.DestAddr != nil {
 		testRequest.DestAddr = overrides.DestAddr
 		if testRequest.Headers == nil {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -747,6 +747,35 @@ func TestApplyInputOverrideSetHostFromDestAddr(t *testing.T) {
 	assert.Equal(t, overrideHost, hostHeader, "Host header must be identical to `dest_addr` after overrding `dest_addr`")
 }
 
+func TestApplyInputOverrideSetHostFromHostHeaderOverride(t *testing.T) {
+	originalDestAddr := "original.com"
+	overrideHostHeader := "override.com"
+	testConfig := `
+---
+testoverride:
+  dest_addr: wrong.org
+  input:
+    headers:
+      Host: %s
+`
+
+	cfg, err1 := config.NewConfigFromString(fmt.Sprintf(testConfig, overrideHostHeader))
+	assert.NoError(t, err1)
+
+	testInput := test.Input{
+		DestAddr: &originalDestAddr,
+	}
+
+	err := applyInputOverride(cfg.TestOverride, &testInput)
+	assert.NoError(t, err, "Failed to apply input overrides")
+
+	assert.NotNil(t, testInput.Headers, "Header map must exist after overriding the `Host` header")
+
+	hostHeader := testInput.Headers.Get("Host")
+	assert.NotEqual(t, "", hostHeader, "Host header must be set after overriding the `Host` header")
+	assert.Equal(t, overrideHostHeader, hostHeader, "Host header must be identical to overridden `Host` header.")
+}
+
 func TestIgnoredTestsRun(t *testing.T) {
 	cfg, err := config.NewConfigFromString(yamlConfigIgnoreTests)
 	dest, logFilePath := newTestServer(t, cfg, logText)


### PR DESCRIPTION
Allows a default Host header to be set in the `testoverride` section of the config:

```
---
testoverride:
  dest_addr: some.example.org
  input:
    headers:
      Host: another.example.org
```

It will take precedense over `dest_addr` if it is specified as well. It will only be set if the input stage does not already have a host header set.

Falling back to using the DestAddr override if it's not specified.