### PR TITLE
feat: fail tests immediately if `NoError()` fails

### DIFF
--- a/check/base_test.go
+++ b/check/base_test.go
@@ -39,9 +39,9 @@ func (s *checkBaseTestSuite) BeforeTest(_, name string) {
 	var err error
 	var logName string
 	s.cfg, err = config.NewConfigFromString(configMap[name])
-	s.NoError(err)
+	s.Require().NoError(err)
 	logName, err = utils.CreateTempFileWithContent(logText, "test-*.log")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.cfg.WithLogfile(logName)
 }
 
@@ -51,7 +51,7 @@ func TestCheckBaseTestSuite(t *testing.T) {
 
 func (s *checkBaseTestSuite) TestNewCheck() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	for _, text := range c.cfg.TestOverride.Ignore {
 		s.Equal(text, "Ignore Me", "Well, didn't match Ignore Me")
@@ -75,7 +75,7 @@ func (s *checkBaseTestSuite) TestNewCheck() {
 
 func (s *checkBaseTestSuite) TestForced() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.True(c.ForcedIgnore("942200-1"), "Can't find ignored value")
 
@@ -94,7 +94,7 @@ func (s *checkBaseTestSuite) TestForced() {
 
 func (s *checkBaseTestSuite) TestCloudMode() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.True(c.CloudMode(), "couldn't detect cloud mode")
 
@@ -128,7 +128,7 @@ func (s *checkBaseTestSuite) TestCloudMode() {
 
 func (s *checkBaseTestSuite) TestSetMarkers() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	c.SetStartMarker([]byte("TesTingStArtMarKer"))
 	c.SetEndMarker([]byte("TestIngEnDMarkeR"))

--- a/check/error_test.go
+++ b/check/error_test.go
@@ -41,12 +41,12 @@ func (s *checkErrorTestSuite) SetupTest() {
 	s.cfg = config.NewDefaultConfig()
 
 	logName, err := utils.CreateTempFileWithContent(logText, "test-*.log")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.cfg.WithLogfile(logName)
 }
 func (s *checkErrorTestSuite) TestAssertResponseErrorOK() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	for _, e := range expectedOKTests {
 		c.SetExpectError(e.expected)
 		s.Equal(e.expected, c.AssertExpectError(e.err))
@@ -55,7 +55,7 @@ func (s *checkErrorTestSuite) TestAssertResponseErrorOK() {
 
 func (s *checkErrorTestSuite) TestAssertResponseFail() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	for _, e := range expectedFailTests {
 		c.SetExpectError(e.expected)

--- a/check/logs_test.go
+++ b/check/logs_test.go
@@ -31,17 +31,17 @@ func (s *checkLogsTestSuite) SetupTest() {
 	s.cfg = config.NewDefaultConfig()
 
 	s.logName, err = utils.CreateTempFileWithContent(logText, "test-*.log")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.cfg.WithLogfile(s.logName)
 }
 
 func (s *checkLogsTestSuite) TearDownTest() {
 	err := os.Remove(s.logName)
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 func (s *checkLogsTestSuite) TestAssertLogContainsOK() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	c.SetLogContains(`id "920300"`)
 	s.True(c.AssertLogContains(), "did not find expected content 'id \"920300\"'")

--- a/check/response_test.go
+++ b/check/response_test.go
@@ -38,13 +38,13 @@ func (s *checkResponseTestSuite) SetupTest() {
 	var err error
 	s.cfg = config.NewDefaultConfig()
 	logName, err := utils.CreateTempFileWithContent(logText, "test-*.log")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.cfg.WithLogfile(logName)
 }
 
 func (s *checkResponseTestSuite) TestAssertResponseTextErrorOK() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	for _, e := range expectedResponseOKTests {
 		c.SetExpectResponse(e.expected)
 		s.Truef(c.AssertResponseContains(e.response), "unexpected response: %v", e.response)
@@ -53,7 +53,7 @@ func (s *checkResponseTestSuite) TestAssertResponseTextErrorOK() {
 
 func (s *checkResponseTestSuite) TestAssertResponseTextFailOK() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	for _, e := range expectedResponseFailTests {
 		c.SetExpectResponse(e.expected)
 		s.Falsef(c.AssertResponseContains(e.response), "response shouldn't contain text %v", e.response)
@@ -62,7 +62,7 @@ func (s *checkResponseTestSuite) TestAssertResponseTextFailOK() {
 
 func (s *checkResponseTestSuite) TestAssertResponseTextChecksFullResponseOK() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	for _, e := range expectedResponseOKTests {
 		c.SetExpectResponse(e.expected)
 		s.Truef(c.AssertResponseContains(e.response), "unexpected response: %v", e.response)
@@ -71,7 +71,7 @@ func (s *checkResponseTestSuite) TestAssertResponseTextChecksFullResponseOK() {
 
 func (s *checkResponseTestSuite) TestAssertResponseContainsRequired() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	c.SetExpectResponse("")
 	s.False(c.AssertResponseContains(""), "response shouldn't contain text")
 	s.False(c.ResponseContainsRequired(), "response shouldn't contain text")

--- a/check/status_test.go
+++ b/check/status_test.go
@@ -36,7 +36,7 @@ func (s *checkStatusTestSuite) SetupTest() {
 	var err error
 	s.cfg = config.NewDefaultConfig()
 	logName, err := utils.CreateTempFileWithContent(logText, "test-*.log")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.cfg.WithLogfile(logName)
 }
 
@@ -46,7 +46,7 @@ func TestCheckStatusTestSuite(t *testing.T) {
 
 func (s *checkStatusTestSuite) TestStatusOK() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	for _, expected := range statusOKTests {
 		c.SetExpectStatus(expected.expectedStatus)
@@ -56,7 +56,7 @@ func (s *checkStatusTestSuite) TestStatusOK() {
 
 func (s *checkStatusTestSuite) TestStatusFail() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	for _, expected := range statusFailTests {
 		c.SetExpectStatus(expected.expectedStatus)
@@ -66,7 +66,7 @@ func (s *checkStatusTestSuite) TestStatusFail() {
 
 func (s *checkStatusTestSuite) TestStatusCodeRequired() {
 	c, err := NewCheck(s.cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	c.SetExpectStatus([]int{200})
 	s.True(c.StatusCodeRequired(), "status code should be required")

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -44,15 +44,15 @@ type checkCmdTestSuite struct {
 
 func (s *checkCmdTestSuite) SetupTest() {
 	tempDir, err := os.MkdirTemp("", "go-ftw-tests")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.tempDir = tempDir
 
 	err = os.MkdirAll(s.tempDir, fs.ModePerm)
-	s.NoError(err)
+	s.Require().NoError(err)
 	testFileContents, err := os.CreateTemp(s.tempDir, "mock-test-*.yaml")
-	s.NoError(err)
+	s.Require().NoError(err)
 	n, err := testFileContents.WriteString(checkFileContents)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(len(checkFileContents), n)
 
 	s.rootCmd = NewRootCommand()
@@ -61,7 +61,7 @@ func (s *checkCmdTestSuite) SetupTest() {
 
 func (s *checkCmdTestSuite) TearDownTest() {
 	err := os.RemoveAll(s.tempDir)
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func TestCheckChoreTestSuite(t *testing.T) {
@@ -71,6 +71,6 @@ func TestCheckChoreTestSuite(t *testing.T) {
 func (s *checkCmdTestSuite) TestCheckCommand() {
 	s.rootCmd.SetArgs([]string{"check", "-d", s.tempDir})
 	cmd, err := s.rootCmd.ExecuteContextC(context.Background())
-	s.NoError(err, "check command should not return an error")
+	s.Require().NoError(err, "check command should not return an error")
 	s.Equal("check", cmd.Name(), "check command should have the name 'check'")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,5 +18,5 @@ func (s *rootCmdTestSuite) TestRootCommand() {
 	rootCmd := NewRootCommand()
 	rootCmd.SetArgs([]string{"help"})
 	err := Execute("v1.0.0")
-	s.NoError(err)
+	s.Require().NoError(err)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -56,36 +56,36 @@ func (s *runCmdTestSuite) setupMockHTTPServer() *httptest.Server {
 		resp := new(bytes.Buffer)
 		for key, value := range r.Header {
 			_, err := fmt.Fprintf(resp, "%s=%s,", key, value)
-			s.NoError(err)
+			s.Require().NoError(err)
 		}
 
 		_, err := w.Write(resp.Bytes())
-		s.NoError(err)
+		s.Require().NoError(err)
 	}))
 	return server
 }
 
 func (s *runCmdTestSuite) SetupTest() {
 	tempDir, err := os.MkdirTemp("", "go-ftw-tests")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.tempDir = tempDir
 
 	s.testHTTPServer = s.setupMockHTTPServer()
 	err = os.MkdirAll(s.tempDir, fs.ModePerm)
-	s.NoError(err)
+	s.Require().NoError(err)
 	testUrl, err := url.Parse(s.testHTTPServer.URL)
-	s.NoError(err)
+	s.Require().NoError(err)
 	port, err := strconv.Atoi(testUrl.Port())
-	s.NoError(err)
+	s.Require().NoError(err)
 	vars := map[string]int{
 		"Port": port,
 	}
 	testFileContents, err := os.CreateTemp(s.tempDir, "mock-test-*.yaml")
-	s.NoError(err)
+	s.Require().NoError(err)
 	tmpl, err := template.New("mock-test").Parse(testFileContentsTemplate)
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = tmpl.Execute(testFileContents, vars)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.rootCmd = NewRootCommand()
 	s.rootCmd.AddCommand(NewRunCommand())
@@ -93,7 +93,7 @@ func (s *runCmdTestSuite) SetupTest() {
 
 func (s *runCmdTestSuite) TearDownTest() {
 	err := os.RemoveAll(s.tempDir)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.testHTTPServer.Close()
 }
 
@@ -114,7 +114,7 @@ func (s *runCmdTestSuite) TestHTTPConnectionSuccess() {
 	s.rootCmd.SetArgs([]string{"run", "--cloud", "-d", s.tempDir, "--wait-for-host", s.testHTTPServer.URL})
 	_, err := s.rootCmd.ExecuteContextC(context.Background())
 
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *runCmdTestSuite) TestHTTPConnectionFail() {
@@ -133,5 +133,5 @@ func (s *runCmdTestSuite) TestHTTPRequestHeaderSuccess() {
 	})
 	_, err := s.rootCmd.ExecuteContextC(context.Background())
 
-	s.NoError(err)
+	s.Require().NoError(err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -64,14 +64,14 @@ func (s *fileTestSuite) BeforeTest(_, name string) {
 	var err error
 	s.filename, _ = utils.CreateTempFileWithContent(testData[name], "test-*.yaml")
 	s.cfg, err = NewConfigFromFile(s.filename)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(s.cfg)
 }
 
 func (s *fileTestSuite) TearDownTest() {
 	if s.filename != "" {
 		err := os.Remove(s.filename)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.filename = ""
 	}
 }
@@ -79,14 +79,14 @@ func (s *fileTestSuite) TearDownTest() {
 func (s *baseTestSuite) TestBaseUnmarshalText() {
 	var ftwRegexp FTWRegexp
 	err := ftwRegexp.UnmarshalText([]byte("test"))
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ftwRegexp)
 	s.True(ftwRegexp.MatchString("This is a test for unmarshalling"), "looks like we could not match string")
 }
 
 func (s *baseTestSuite) TestBaseNewFTWRegexpText() {
 	ftwRegexp, err := NewFTWRegexp("test")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ftwRegexp)
 	s.True(ftwRegexp.MatchString("This is a test"), "looks like we could not match string")
 }
@@ -108,7 +108,7 @@ func (s *fileTestSuite) TestNewConfigBadFileConfig() {
 	filename, _ := utils.CreateTempFileWithContent(testData["jsonConfig"], "test-*.yaml")
 	defer os.Remove(filename)
 	cfg, err := NewConfigFromFile(filename)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 }
 
@@ -136,13 +136,13 @@ func (s *fileTestSuite) TestNewConfigDefaultConfig() {
 	_ = os.WriteFile(s.filename, []byte(testData["ok"]), 0644)
 
 	cfg, err := NewConfigFromFile("")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 }
 
 func (s *fileTestSuite) TestNewConfigFromString() {
 	cfg, err := NewConfigFromString(testData["ok"])
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 }
 
@@ -157,14 +157,14 @@ func (s *fileTestSuite) TestNewConfigFromEnv() {
 	os.Setenv("FTW_LOGFILE", "koanf")
 
 	cfg, err := NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 	s.Equal("koanf", cfg.LogFile)
 }
 
 func (s *fileTestSuite) TestNewConfigFromEnvHasDefaults() {
 	cfg, err := NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	s.Equalf(DefaultRunMode, cfg.RunMode,
@@ -183,7 +183,7 @@ func (s *fileTestSuite) TestNewConfigFromFileHasDefaults() {
 
 func (s *fileTestSuite) TestNewConfigFromStringHasDefaults() {
 	cfg, err := NewConfigFromString("")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 	s.Equalf(DefaultRunMode, cfg.RunMode,
 		"unexpected default value '%s' for run mode", cfg.RunMode)

--- a/ftwhttp/client_test.go
+++ b/ftwhttp/client_test.go
@@ -28,7 +28,7 @@ func TestClientTestSuite(t *testing.T) {
 func (s *clientTestSuite) SetupTest() {
 	var err error
 	s.client, err = NewClient(NewClientConfig())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Nil(s.client.Transport, "Transport not expected to be initialized yet")
 }
 
@@ -48,11 +48,11 @@ func (s *clientTestSuite) httpHandler() http.HandlerFunc {
 		resp := new(bytes.Buffer)
 		for key, value := range r.Header {
 			_, err := fmt.Fprintf(resp, "%s=%s,", key, value)
-			s.NoError(err)
+			s.Require().NoError(err)
 		}
 
 		_, err := w.Write(resp.Bytes())
-		s.NoError(err)
+		s.Require().NoError(err)
 	}
 }
 
@@ -74,24 +74,24 @@ func (s *clientTestSuite) TestNewClient() {
 func (s *clientTestSuite) TestConnectDestinationHTTPS() {
 	s.httpTestServer(secureServer)
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	s.client.SetRootCAs(s.ts.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	err = s.client.NewConnection(*d)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	s.Equal("https", s.client.Transport.protocol, "Error connecting to example.com using https")
 }
 
 func (s *clientTestSuite) TestDoRequest() {
 	s.httpTestServer(secureServer)
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	s.client.SetRootCAs(s.ts.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	req := generateBaseRequestForTesting()
 	req.requestLine.URI = "/not-found"
 	err = s.client.NewConnection(*d)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	response, err := s.client.Do(*req)
-	s.NoError(err, "This should error")
+	s.Require().NoError(err, "This should error")
 	s.Equal(http.StatusNotFound, response.Parsed.StatusCode, "Error in calling website")
 }
 
@@ -114,7 +114,7 @@ func (s *clientTestSuite) TestGetTrackedTime() {
 	req := NewRequest(rl, h, data, true)
 
 	err := s.client.NewConnection(*d)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 
 	s.client.StartTrackingTime()
 
@@ -122,7 +122,7 @@ func (s *clientTestSuite) TestGetTrackedTime() {
 
 	s.client.StopTrackingTime()
 
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	s.Equal(http.StatusOK, resp.Parsed.StatusCode, "Error in calling website")
 
 	rtt := s.client.GetRoundTripTime()
@@ -132,7 +132,7 @@ func (s *clientTestSuite) TestGetTrackedTime() {
 func (s *clientTestSuite) TestClientMultipartFormDataRequest() {
 	s.httpTestServer(secureServer)
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 
 	s.client.SetRootCAs(s.ts.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 
@@ -157,7 +157,7 @@ Some-file-test-here
 	req := NewRequest(rl, h, data, true)
 
 	err = s.client.NewConnection(*d)
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 
 	s.client.StartTrackingTime()
 
@@ -165,7 +165,7 @@ Some-file-test-here
 
 	s.client.StopTrackingTime()
 
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	s.Equal(http.StatusOK, resp.Parsed.StatusCode, "Error in calling website")
 
 }
@@ -173,10 +173,10 @@ Some-file-test-here
 func (s *clientTestSuite) TestNewConnectionCreatesTransport() {
 	s.httpTestServer(secureServer)
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err, "Failed to construct destination from test server")
+	s.Require().NoError(err, "Failed to construct destination from test server")
 	s.client.SetRootCAs(s.ts.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	err = s.client.NewConnection(*d)
-	s.NoError(err, "Failed to create new connection")
+	s.Require().NoError(err, "Failed to create new connection")
 	s.NotNil(s.client.Transport, "Transport expected to be initialized")
 	s.NotNil(s.client.Transport.connection, "Connection expected to be initialized")
 }
@@ -184,10 +184,10 @@ func (s *clientTestSuite) TestNewConnectionCreatesTransport() {
 func (s *clientTestSuite) TestNewOrReusedConnectionCreatesTransport() {
 	s.httpTestServer(secureServer)
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err, "Failed to construct destination from test server")
+	s.Require().NoError(err, "Failed to construct destination from test server")
 	s.client.SetRootCAs(s.ts.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	err = s.client.NewOrReusedConnection(*d)
-	s.NoError(err, "Failed to create new or to reuse connection")
+	s.Require().NoError(err, "Failed to create new or to reuse connection")
 	s.NotNil(s.client.Transport, "Transport expected to be initialized")
 	s.NotNil(s.client.Transport.connection, "Connection expected to be initialized")
 }
@@ -195,16 +195,16 @@ func (s *clientTestSuite) TestNewOrReusedConnectionCreatesTransport() {
 func (s *clientTestSuite) TestNewOrReusedConnectionReusesTransport() {
 	s.httpTestServer(insecureServer)
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err, "Failed to construct destination from test server")
+	s.Require().NoError(err, "Failed to construct destination from test server")
 
 	err = s.client.NewOrReusedConnection(*d)
-	s.NoError(err, "Failed to create new or to reuse connection")
+	s.Require().NoError(err, "Failed to create new or to reuse connection")
 	s.NotNil(s.client.Transport, "Transport expected to be initialized")
 	s.NotNil(s.client.Transport.connection, "Connection expected to be initialized")
 
 	begin := s.client.Transport.duration.begin
 	err = s.client.NewOrReusedConnection(*d)
-	s.NoError(err, "Failed to reuse connection")
+	s.Require().NoError(err, "Failed to reuse connection")
 
 	s.Equal(begin, s.client.Transport.duration.begin, "Transport must not be reinitialized when reusing connection")
 }

--- a/ftwhttp/connection_test.go
+++ b/ftwhttp/connection_test.go
@@ -16,7 +16,7 @@ func TestConnectionTestSuite(t *testing.T) {
 
 func (s *connectionTestSuite) TestDestinationFromString() {
 	d, err := DestinationFromString("http://example.com:80")
-	s.NoError(err, "This should not error")
+	s.Require().NoError(err, "This should not error")
 	s.Equal("example.com", d.DestAddr, "Error parsing destination")
 	s.Equal(80, d.Port, "Error parsing destination")
 	s.Equal("http", d.Protocol, "Error parsing destination")

--- a/ftwhttp/header_test.go
+++ b/ftwhttp/header_test.go
@@ -70,12 +70,12 @@ func TestHeaderTestSuite(t *testing.T) {
 func (s *headerTestSuite) TestHeaderWrite() {
 	for _, test := range headerWriteTests {
 		err := test.h.Write(io.Discard)
-		s.NoError(err)
+		s.Require().NoError(err)
 		err = test.h.Write(BadWriter{err: errors.New("fake error")})
 		if len(test.h) > 0 {
 			s.EqualErrorf(err, "fake error", "Write: got %v, want %v", err, "fake error")
 		} else {
-			s.NoErrorf(err, "Write: got %v", err)
+			s.Require().NoErrorf(err, "Write: got %v", err)
 		}
 	}
 }
@@ -87,7 +87,7 @@ func (s *headerTestSuite) TestHeaderWriteBytes() {
 		n, err := test.h.WriteBytes(&buf)
 		w := buf.String()
 		s.Lenf(w, n, "#%d: WriteBytes: got %d, want %d", i, n, len(w))
-		s.NoErrorf(err, "#%d: WriteBytes: got %v", i, err)
+		s.Require().NoErrorf(err, "#%d: WriteBytes: got %v", i, err)
 		s.Equalf(test.expected, w, "#%d: WriteBytes: got %q, want %q", i, w, test.expected)
 		buf.Reset()
 	}
@@ -99,7 +99,7 @@ func (s *headerTestSuite) TestHeaderWriteString() {
 	for i, test := range headerWriteTests {
 		expected := test.h.Get("Content-Type")
 		n, err := sw.WriteString(expected)
-		s.NoErrorf(err, "#%d: WriteString: %v", i, err)
+		s.Require().NoErrorf(err, "#%d: WriteString: %v", i, err)
 		s.Equalf(len(expected), n, "#%d: WriteString: got %d, want %d", i, n, len(expected))
 	}
 }

--- a/ftwhttp/request_test.go
+++ b/ftwhttp/request_test.go
@@ -240,7 +240,7 @@ func (s *requestTestSuite) TestRequestData() {
 
 	err := req.SetData([]byte("This is the data now"))
 
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal([]byte("This is the data now"), req.Data(), "failed to set data")
 }
 
@@ -258,7 +258,7 @@ func (s *requestTestSuite) TestRequestRawData() {
 	req := generateBaseRawRequestForTesting()
 
 	err := req.SetRawData([]byte("This is the RAW data now"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal([]byte("This is the RAW data now"), req.RawData())
 }
@@ -279,7 +279,7 @@ func (s *requestTestSuite) TestRequestURLParse() {
 	h.Add(ContentTypeHeader, "application/x-www-form-urlencoded")
 	// Test adding semicolons to test parse
 	err := req.SetData([]byte("test=This&test=nothing"))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *requestTestSuite) TestRequestURLParseFail() {
@@ -289,7 +289,7 @@ func (s *requestTestSuite) TestRequestURLParseFail() {
 	h.Add(ContentTypeHeader, "application/x-www-form-urlencoded")
 	// Test adding semicolons to test parse
 	err := req.SetData([]byte("test=This&that=but with;;;;;; data now"))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *requestTestSuite) TestRequestEncodesPostData() {
@@ -333,9 +333,9 @@ func (s *requestTestSuite) TestRequestEncodesPostData() {
 			h := req.Headers()
 			h.Add(ContentTypeHeader, "application/x-www-form-urlencoded")
 			err := req.SetData([]byte(tt.raw))
-			s.NoError(err)
+			s.Require().NoError(err)
 			result, err := encodeDataParameters(h, req.Data())
-			s.NoError(err, "Failed to encode %s", req.Data())
+			s.Require().NoError(err, "Failed to encode %s", req.Data())
 
 			expected := tt.encoded
 			actual := string(result)

--- a/ftwhttp/response_test.go
+++ b/ftwhttp/response_test.go
@@ -70,7 +70,7 @@ func generateRequestWithCookiesForTesting() *Request {
 
 func (s *responseTestSuite) helloClient(w http.ResponseWriter, r *http.Request) {
 	n, err := fmt.Fprintln(w, "Hello, client")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(14, n)
 }
 
@@ -80,10 +80,10 @@ func (s *responseTestSuite) testEchoServer(w http.ResponseWriter, r *http.Reques
 	resp := new(bytes.Buffer)
 	for key, value := range r.Header {
 		_, err := fmt.Fprintf(resp, "%s=%s,", key, value)
-		s.NoError(err)
+		s.Require().NoError(err)
 	}
 	_, err := w.Write(resp.Bytes())
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *responseTestSuite) responseWithCookies(w http.ResponseWriter, r *http.Request) {
@@ -91,14 +91,14 @@ func (s *responseTestSuite) responseWithCookies(w http.ResponseWriter, r *http.R
 	cookie := http.Cookie{Name: "username", Value: "go-ftw", Expires: expiration}
 	http.SetCookie(w, &cookie)
 	n, err := fmt.Fprintln(w, "Setting Cookies!")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(17, n)
 }
 
 func (s *responseTestSuite) SetupTest() {
 	var err error
 	s.client, err = NewClient(NewClientConfig())
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *responseTestSuite) TearDownTest() {
@@ -122,48 +122,48 @@ func (s *responseTestSuite) BeforeTest(_, testName string) {
 
 func (s *responseTestSuite) TestResponse() {
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	req := generateRequestForTesting(true)
 
 	err = s.client.NewConnection(*d)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	response, err := s.client.Do(*req)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Contains(response.GetFullResponse(), "Hello, client\n")
 }
 
 func (s *responseTestSuite) TestResponseWithCookies() {
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err)
+	s.Require().NoError(err)
 	req := generateRequestForTesting(true)
 
 	err = s.client.NewConnection(*d)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	response, err := s.client.Do(*req)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Contains(response.GetFullResponse(), "Setting Cookies!\n")
 
 	cookiereq := generateRequestWithCookiesForTesting()
 
 	_, err = s.client.Do(*cookiereq)
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *responseTestSuite) TestResponseChecksFullResponse() {
 	d, err := DestinationFromString(s.ts.URL)
-	s.NoError(err)
+	s.Require().NoError(err)
 	req := generateRequestForTesting(true)
 
 	err = s.client.NewConnection(*d)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	response, err := s.client.Do(*req)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Contains(response.GetFullResponse(), "X-Powered-By: go-ftw")
 	s.Contains(response.GetFullResponse(), "User-Agent=[Go Tests]")

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -42,7 +42,7 @@ func (s *outputTestSuite) TestOutput() {
 		o := NewOutput(test.oType, &b)
 
 		err := o.Printf(format, testString)
-		s.NoError(err, "Error! in test %d", i)
+		s.Require().NoError(err, "Error! in test %d", i)
 	}
 }
 

--- a/runner/run_cloud_test.go
+++ b/runner/run_cloud_test.go
@@ -40,7 +40,7 @@ func (s *runCloudTestSuite) TearDownTest() {
 	s.ts.Close()
 	if s.tempFileName != "" {
 		err := os.Remove(s.tempFileName)
-		s.NoError(err, "cannot remove test file")
+		s.Require().NoError(err, "cannot remove test file")
 		s.tempFileName = ""
 	}
 }
@@ -52,7 +52,7 @@ func (s *runCloudTestSuite) BeforeTest(_ string, name string) {
 	// else use the default destination
 	if s.dest == nil {
 		s.dest, err = ftwhttp.DestinationFromString(destinationMap[name])
-		s.NoError(err)
+		s.Require().NoError(err)
 	}
 
 	log.Info().Msgf("Using port %d and addr '%s'", s.dest.Port, s.dest.DestAddr)
@@ -66,15 +66,15 @@ func (s *runCloudTestSuite) BeforeTest(_ string, name string) {
 	s.cfg = config.NewCloudConfig()
 	// get tests template from file
 	tmpl, err := template.ParseFiles(fmt.Sprintf("testdata/%s.yaml", name))
-	s.NoError(err)
+	s.Require().NoError(err)
 	// create a temporary file to hold the test
 	testFileContents, err := os.CreateTemp("testdata", "mock-test-*.yaml")
-	s.NoError(err, "cannot create temporary file")
+	s.Require().NoError(err, "cannot create temporary file")
 	err = tmpl.Execute(testFileContents, vars)
-	s.NoError(err, "cannot execute template")
+	s.Require().NoError(err, "cannot execute template")
 	// get tests from file
 	s.ftwTests, err = test.GetTestsFromFiles(testFileContents.Name())
-	s.NoError(err, "cannot get tests from file")
+	s.Require().NoError(err, "cannot get tests from file")
 	// save the name of the temporary file so we can delete it later
 	s.tempFileName = testFileContents.Name()
 }
@@ -106,7 +106,7 @@ func (s *runCloudTestSuite) TestCloudRun() {
 			ShowTime: true,
 			Output:   output.Quiet,
 		}, s.out)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equalf(res.Stats.TotalFailed(), 0, "Oops, %d tests failed to run!", res.Stats.TotalFailed())
 	})
 }

--- a/runner/run_input_override_test.go
+++ b/runner/run_input_override_test.go
@@ -127,12 +127,12 @@ func (s *inputOverrideTestSuite) BeforeTest(_ string, name string) {
 	// set up configuration from template
 	tmpl := template.New("input-override").Funcs(sprig.TxtFuncMap())
 	configTmpl, err := tmpl.Parse(configTemplate)
-	s.NoError(err, "cannot parse template")
+	s.Require().NoError(err, "cannot parse template")
 	buf := &bytes.Buffer{}
 	err = configTmpl.Execute(buf, overrideConfigMap[name])
-	s.NoError(err, "cannot execute template")
+	s.Require().NoError(err, "cannot execute template")
 	s.cfg, err = config.NewConfigFromString(buf.String())
-	s.NoError(err, "cannot get config from string")
+	s.Require().NoError(err, "cannot get config from string")
 	if s.logFilePath != "" {
 		s.cfg.WithLogfile(s.logFilePath)
 	}
@@ -141,7 +141,7 @@ func (s *inputOverrideTestSuite) BeforeTest(_ string, name string) {
 func (s *inputOverrideTestSuite) TestSetHostFromDestAddr() {
 	originalHost := "original.com"
 	overrideHost, err := getOverrideConfigValue("DestAddr")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		DestAddr: &originalHost,
@@ -156,7 +156,7 @@ func (s *inputOverrideTestSuite) TestSetHostFromDestAddr() {
 	}
 
 	err = applyInputOverride(cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 
 	s.Equal(overrideHost, *testInput.DestAddr, "`dest_addr` should have been overridden")
 
@@ -170,14 +170,14 @@ func (s *inputOverrideTestSuite) TestSetHostFromDestAddr() {
 func (s *inputOverrideTestSuite) TestSetHostFromHostHeaderOverride() {
 	originalDestAddr := "original.com"
 	overrideHostHeader, err := getOverrideConfigValue("Headers.Host")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		DestAddr: &originalDestAddr,
 	}
 
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 
 	hostHeader := testInput.Headers.Get("Host")
 	s.NotEqual("", hostHeader, "Host header must be set after overriding the `Host` header")
@@ -191,7 +191,7 @@ func (s *inputOverrideTestSuite) TestSetHostFromHostHeaderOverride() {
 func (s *inputOverrideTestSuite) TestSetHeaderOverridingExistingOne() {
 	originalHeaderValue := "original"
 	overrideHeaderValue, err := getOverrideConfigValue("Headers.UniqueID")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		Headers: ftwhttp.Header{"unique_id": originalHeaderValue},
@@ -200,7 +200,7 @@ func (s *inputOverrideTestSuite) TestSetHeaderOverridingExistingOne() {
 	s.NotNil(testInput.Headers, "Header map must exist before overriding any header")
 
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 
 	overriddenHeader := testInput.Headers.Get("unique_id")
 	s.NotEqual("", overriddenHeader, "unique_id header must be set after overriding it")
@@ -210,7 +210,7 @@ func (s *inputOverrideTestSuite) TestSetHeaderOverridingExistingOne() {
 func (s *inputOverrideTestSuite) TestApplyInputOverrides() {
 	originalHeaderValue := "original"
 	overrideHeaderValue, err := getOverrideConfigValue("Headers.UniqueID")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		Headers: ftwhttp.Header{"unique_id": originalHeaderValue},
@@ -219,7 +219,7 @@ func (s *inputOverrideTestSuite) TestApplyInputOverrides() {
 	s.NotNil(testInput.Headers, "Header map must exist before overriding any header")
 
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 
 	overriddenHeader := testInput.Headers.Get("unique_id")
 	s.NotEqual("", overriddenHeader, "unique_id header must be set after overriding it")
@@ -229,91 +229,91 @@ func (s *inputOverrideTestSuite) TestApplyInputOverrides() {
 func (s *inputOverrideTestSuite) TestApplyInputOverrideURI() {
 	originalURI := "/original"
 	overrideURI, err := getOverrideConfigValue("URI")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		URI: &originalURI,
 	}
 
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideURI, *testInput.URI, "`URI` should have been overridden")
 }
 
 func (s *inputOverrideTestSuite) TestApplyInputOverrideVersion() {
 	originalVersion := "HTTP/0.9"
 	overrideVersion, err := getOverrideConfigValue("Version")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		Version: &originalVersion,
 	}
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideVersion, *testInput.Version, "`Version` should have been overridden")
 }
 
 func (s *inputOverrideTestSuite) TestApplyInputOverrideMethod() {
 	originalMethod := "POST"
 	overrideMethod, err := getOverrideConfigValue("Method")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		Method: &originalMethod,
 	}
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideMethod, *testInput.Method, "`Method` should have been overridden")
 }
 
 func (s *inputOverrideTestSuite) TestApplyInputOverrideData() {
 	originalData := "data"
 	overrideData, err := getOverrideConfigValue("Data")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		Data: &originalData,
 	}
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideData, *testInput.Data, "`Data` should have been overridden")
 }
 
 func (s *inputOverrideTestSuite) TestApplyInputOverrideStopMagic() {
 	stopMagicBool, err := getOverrideConfigValue("StopMagic")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 	overrideStopMagic, err := strconv.ParseBool(stopMagicBool)
-	s.NoError(err, "Failed to parse `StopMagic` override value")
+	s.Require().NoError(err, "Failed to parse `StopMagic` override value")
 	testInput := test.Input{
 		StopMagic: false,
 	}
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideStopMagic, testInput.StopMagic, "`StopMagic` should have been overridden")
 }
 
 func (s *inputOverrideTestSuite) TestApplyInputOverrideEncodedRequest() {
 	originalEncodedRequest := "originalbase64"
 	overrideEncodedRequest, err := getOverrideConfigValue("EncodedRequest")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 	testInput := test.Input{
 		EncodedRequest: originalEncodedRequest,
 	}
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideEncodedRequest, testInput.EncodedRequest, "`EncodedRequest` should have been overridden")
 }
 
 func (s *inputOverrideTestSuite) TestApplyInputOverrideRAWRequest() {
 	originalRAWRequest := "original"
 	overrideRAWRequest, err := getOverrideConfigValue("RawRequest")
-	s.NoError(err, "cannot get override value")
+	s.Require().NoError(err, "cannot get override value")
 
 	testInput := test.Input{
 		RAWRequest: originalRAWRequest,
 	}
 
 	err = applyInputOverride(s.cfg.TestOverride, &testInput)
-	s.NoError(err, "Failed to apply input overrides")
+	s.Require().NoError(err, "Failed to apply input overrides")
 	s.Equal(overrideRAWRequest, testInput.RAWRequest, "`RAWRequest` should have been overridden")
 }

--- a/test/data_test.go
+++ b/test/data_test.go
@@ -34,7 +34,7 @@ uri: "/"
 `
 	input := Input{}
 	err := yaml.Unmarshal([]byte(yamlString), &input)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.True(input.StopMagic)
 }
 
@@ -55,7 +55,7 @@ uri: "/"
 `
 	input := Input{}
 	err := yaml.Unmarshal([]byte(yamlString), &input)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Empty(*input.Version)
 }
 
@@ -78,7 +78,7 @@ uri: "/"
 	var data []byte
 	err := yaml.Unmarshal([]byte(yamlString), &input)
 
-	s.NoError(err)
+	s.Require().NoError(err)
 	data = input.ParseData()
 	s.Equal([]byte(repeatTestSprig), data)
 }

--- a/utils/tests_test.go
+++ b/utils/tests_test.go
@@ -22,7 +22,7 @@ func (s *testFilesTestSuite) TestCreateTempFile() {
 	// Remember to clean up the file afterwards
 	defer os.Remove(filename)
 
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *testFilesTestSuite) TestCreateBadTempFile() {

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -28,7 +28,7 @@ func (s *readTestSuite) TearDownSuite() {
 
 func (s *readTestSuite) TestReadCheckLogForMarkerNoMarkerAtEnd() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -40,12 +40,12 @@ func (s *readTestSuite) TestReadCheckLogForMarkerNoMarkerAtEnd() {
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 `
 	s.filename, err = utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = s.filename
 
 	ll, err := NewFTWLogLines(cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	ll.WithStartMarker([]byte(markerLine))
 	marker := ll.CheckLogForMarker(stageID, 100)
 	s.Equal(string(marker), strings.ToLower(markerLine), "unexpectedly found marker")
@@ -53,7 +53,7 @@ func (s *readTestSuite) TestReadCheckLogForMarkerNoMarkerAtEnd() {
 
 func (s *readTestSuite) TestReadCheckLogForMarkerWithMarkerAtEnd() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -64,13 +64,13 @@ func (s *readTestSuite) TestReadCheckLogForMarkerWithMarkerAtEnd() {
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 ` + markerLine
 	s.filename, err = utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = s.filename
 
 	ll, err := NewFTWLogLines(cfg)
 	ll.WithStartMarker([]byte(markerLine))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	marker := ll.CheckLogForMarker(stageID, 100)
 	s.NotNil(marker, "no marker found")
@@ -80,7 +80,7 @@ func (s *readTestSuite) TestReadCheckLogForMarkerWithMarkerAtEnd() {
 
 func (s *readTestSuite) TestReadGetMarkedLines() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -92,12 +92,12 @@ func (s *readTestSuite) TestReadGetMarkedLines() {
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`
 	logLines := fmt.Sprintf("%s\n%s\n%s", startMarkerLine, logLinesOnly, endMarkerLine)
 	s.filename, err = utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = s.filename
 
 	ll, err := NewFTWLogLines(cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
 	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
 
@@ -117,7 +117,7 @@ func (s *readTestSuite) TestReadGetMarkedLines() {
 
 func (s *readTestSuite) TestReadGetMarkedLinesWithTrailingEmptyLines() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -129,12 +129,12 @@ func (s *readTestSuite) TestReadGetMarkedLinesWithTrailingEmptyLines() {
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`
 	logLines := fmt.Sprintf("%s\n%s\n%s\n\n\n", startMarkerLine, logLinesOnly, endMarkerLine)
 	s.filename, err = utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = s.filename
 
 	ll, err := NewFTWLogLines(cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
 	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
 
@@ -154,7 +154,7 @@ func (s *readTestSuite) TestReadGetMarkedLinesWithTrailingEmptyLines() {
 
 func (s *readTestSuite) TestReadGetMarkedLinesWithPrecedingLines() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -169,12 +169,12 @@ func (s *readTestSuite) TestReadGetMarkedLinesWithPrecedingLines() {
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`
 	logLines := fmt.Sprintf("%s\n%s\n%s\n%s\n", precedingLines, startMarkerLine, logLinesOnly, endMarkerLine)
 	s.filename, err = utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = s.filename
 
 	ll, err := NewFTWLogLines(cfg)
-	s.NoError(err)
+	s.Require().NoError(err)
 	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
 	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
 
@@ -194,7 +194,7 @@ func (s *readTestSuite) TestReadGetMarkedLinesWithPrecedingLines() {
 
 func (s *readTestSuite) TestFTWLogLines_Contains() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -205,11 +205,11 @@ func (s *readTestSuite) TestFTWLogLines_Contains() {
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 ` + markerLine
 	s.filename, err = utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = s.filename
 	log, err := os.Open(s.filename)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	type fields struct {
 		logFile             *os.File
@@ -266,7 +266,7 @@ func (s *readTestSuite) TestFTWLogLines_Contains() {
 
 func (s *readTestSuite) TestFTWLogLines_ContainsIn404() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -278,11 +278,11 @@ func (s *readTestSuite) TestFTWLogLines_ContainsIn404() {
 		`[2022-11-12 23:08:18.013007] [core:info] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 AH00128: File does not exist: /apache/htdocs/status/200`,
 		"\n", markerLine)
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = filename
 	log, err := os.Open(filename)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	type fields struct {
 		logFile             *os.File
@@ -331,7 +331,7 @@ func (s *readTestSuite) TestFTWLogLines_ContainsIn404() {
 
 func (s *readTestSuite) TestFTWLogLines_CheckForLogMarkerIn404() {
 	cfg, err := config.NewConfigFromEnv()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(cfg)
 
 	stageID := "dead-beaf-deadbeef-deadbeef-dead"
@@ -343,11 +343,11 @@ func (s *readTestSuite) TestFTWLogLines_CheckForLogMarkerIn404() {
 		`[2022-11-12 23:08:18.013007] [core:info] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 AH00128: File does not exist: /apache/htdocs/status/200`,
 		"\n", markerLine)
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cfg.LogFile = filename
 	log, err := os.Open(filename)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ll := &FTWLogLines{
 		logFile:             log,

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -28,5 +28,5 @@ func (s *waflogTestSuite) TestNewFTWLogLines() {
 	s.NotNil(ll.StartMarker, "Failed! StartMarker must be set")
 	s.NotNil(ll.EndMarker, "Failed! EndMarker must be set")
 	err := ll.Cleanup()
-	s.NoError(err)
+	s.Require().NoError(err)
 }


### PR DESCRIPTION
The testify test suite offers a `Required()` context that will fail immediately on failure. For `NoError()` we want assertions to always fail immediately because continuing doesn't make sense and just spams the log.