### PR TITLE
fix: reduce log level when writing headers

### DIFF
--- a/ftwhttp/header.go
+++ b/ftwhttp/header.go
@@ -102,7 +102,7 @@ func (h Header) WriteBytes(b *bytes.Buffer) (int, error) {
 	for _, key := range sorted {
 		// we want all headers "as-is"
 		s := key + ": " + h[key] + "\r\n"
-		log.Debug().Msgf("Writing header: %s", s)
+		log.Trace().Msgf("Writing header: %s", s)
 		n, err := b.Write([]byte(s))
 		count += n
 		if err != nil {

--- a/ftwhttp/header.go
+++ b/ftwhttp/header.go
@@ -102,7 +102,7 @@ func (h Header) WriteBytes(b *bytes.Buffer) (int, error) {
 	for _, key := range sorted {
 		// we want all headers "as-is"
 		s := key + ": " + h[key] + "\r\n"
-		log.Info().Msgf("Writing header: %s", s)
+		log.Debug().Msgf("Writing header: %s", s)
 		n, err := b.Write([]byte(s))
 		count += n
 		if err != nil {
@@ -111,7 +111,6 @@ func (h Header) WriteBytes(b *bytes.Buffer) (int, error) {
 	}
 
 	return count, nil
-
 }
 
 // Clone returns a copy of h or nil if h is nil.


### PR DESCRIPTION
Multiple log entries are produced for each test, for each HTTP header written.