### PR TITLE
fix: no longer negate `autocomplete_headers` option

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -362,7 +362,7 @@ func getRequestFromTest(testInput test.Input) *ftwhttp.Request {
 
 	// If we use raw or encoded request, then we don't use other fields
 	if raw != nil {
-		req = ftwhttp.NewRawRequest(raw, !*testInput.AutocompleteHeaders)
+		req = ftwhttp.NewRawRequest(raw, *testInput.AutocompleteHeaders)
 	} else {
 		rline := &ftwhttp.RequestLine{
 			Method:  testInput.GetMethod(),
@@ -373,7 +373,7 @@ func getRequestFromTest(testInput test.Input) *ftwhttp.Request {
 		data := testInput.ParseData()
 		// create a new request
 		req = ftwhttp.NewRequest(rline, testInput.Headers,
-			data, !*testInput.AutocompleteHeaders)
+			data, *testInput.AutocompleteHeaders)
 
 	}
 	return req

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -360,6 +360,8 @@ func (s *runTestSuite) TestGetRequestFromTestWithAutocompleteHeaders() {
 		Method:              &method,
 		Headers:             ftwhttp.Header{},
 		DestAddr:            &s.dest.DestAddr,
+		Port:                &s.dest.Port,
+		Protocol:            &s.dest.Protocol,
 	}
 	request := getRequestFromTest(input)
 
@@ -388,6 +390,8 @@ func (s *runTestSuite) TestGetRawRequestFromTestWithAutocompleteHeaders() {
 		Method:              &method,
 		Headers:             ftwhttp.Header{},
 		DestAddr:            &s.dest.DestAddr,
+		Port:                &s.dest.Port,
+		Protocol:            &s.dest.Protocol,
 		RAWRequest:          "POST / HTTP/1.1\r\nHost: localhost\r\nUser-Agent: test\r\n\r\n",
 	}
 	request := getRequestFromTest(input)
@@ -417,6 +421,8 @@ func (s *runTestSuite) TestGetRequestFromTestWithoutAutocompleteHeaders() {
 		Method:              &method,
 		Headers:             ftwhttp.Header{},
 		DestAddr:            &s.dest.DestAddr,
+		Port:                &s.dest.Port,
+		Protocol:            &s.dest.Protocol,
 	}
 	request := getRequestFromTest(input)
 


### PR DESCRIPTION
When the logic was inverted, as we renamed `stop_magic` to `autocomplete_headers`, we forgot to remove the logic inversion when passing the option to the request builder.