### PR TITLE
chore: make MendRenovate ignore updates to go-yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "ignoreDeps": ["goccy/go-yaml"],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
goccy/go-yaml still has a performance issue in versions > v1.9.2.