### PR TITLE
fix: properly handle multiple IDs in positive log match

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,21 +14,6 @@ repos:
       name: go-cyclo
       alias: go-cyclo
       args: [ gocyclo, -over=15]
-    - id: my-cmd
-      name: "Check files aren't using go's testing package"
-      entry: 'testing\.T'
-      files: 'test_.*\.go$'
-      language: 'pygrep'
-      description: >
-        Checks that no files are using `testing.T`, if you want developers to use
-        a different testing framework
-    - id: my-cmd
-      name: 'validate toml'
-      entry: 'tomlv'
-      files: '\.toml$'
-      language: 'system'
-      description: >
-        Runs `tomlv`, requires https://github.com/BurntSushi/toml/tree/master/cmd/tomlv"
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.18.1
   hooks:

--- a/check/base.go
+++ b/check/base.go
@@ -4,9 +4,8 @@
 package check
 
 import (
-	"bytes"
-
 	schema "github.com/coreruleset/ftw-tests-schema/types"
+
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/test"
 	"github.com/coreruleset/go-ftw/waflog"
@@ -105,10 +104,10 @@ func (c *FTWCheck) CloudMode() bool {
 
 // SetStartMarker sets the log line that marks the start of the logs to analyze
 func (c *FTWCheck) SetStartMarker(marker []byte) {
-	c.log.StartMarker = bytes.ToLower(marker)
+	c.log.WithStartMarker(marker)
 }
 
 // SetEndMarker sets the log line that marks the end of the logs to analyze
 func (c *FTWCheck) SetEndMarker(marker []byte) {
-	c.log.EndMarker = bytes.ToLower(marker)
+	c.log.WithEndMarker(marker)
 }

--- a/check/base_test.go
+++ b/check/base_test.go
@@ -6,9 +6,9 @@ package check
 import (
 	"testing"
 
+	schema "github.com/coreruleset/ftw-tests-schema/types"
 	"github.com/stretchr/testify/suite"
 
-	schema "github.com/coreruleset/ftw-tests-schema/types"
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/test"
 	"github.com/coreruleset/go-ftw/utils"
@@ -101,6 +101,6 @@ func (s *checkBaseTestSuite) TestSetMarkers() {
 
 	c.SetStartMarker([]byte("TesTingStArtMarKer"))
 	c.SetEndMarker([]byte("TestIngEnDMarkeR"))
-	s.Equal([]byte("testingstartmarker"), c.log.StartMarker, "Couldn't set start marker")
-	s.Equal([]byte("testingendmarker"), c.log.EndMarker, "Couldn't set end marker")
+	s.Equal("testingstartmarker", string(c.log.StartMarker()), "Couldn't set start marker")
+	s.Equal("testingendmarker", string(c.log.EndMarker()), "Couldn't set end marker")
 }

--- a/check/logs.go
+++ b/check/logs.go
@@ -4,9 +4,6 @@
 package check
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/rs/zerolog/log"
 )
 
@@ -24,15 +21,16 @@ func (c *FTWCheck) assertNoLogContains() bool {
 	logExpectations := c.expected.Log
 	result := true
 	if logExpectations.NoMatchRegex != "" {
-		result = !c.log.Contains(logExpectations.NoMatchRegex)
+		result = !c.log.MatchesRegex(logExpectations.NoMatchRegex)
 		if !result {
 			log.Debug().Msgf("Unexpectedly found match for '%s'", logExpectations.NoMatchRegex)
 		}
 	}
 	if result && len(logExpectations.NoExpectIds) > 0 {
-		result = !c.log.Contains(generateIdRegex(logExpectations.NoExpectIds))
-		if !result {
-			log.Debug().Msg("Unexpectedly found IDs")
+		found, foundRules := c.log.ContainsAnyId(logExpectations.NoExpectIds)
+		if found {
+			log.Debug().Msgf("Unexpectedly found the following IDs in the log: %v", foundRules)
+			result = false
 		}
 	}
 	return result
@@ -43,36 +41,18 @@ func (c *FTWCheck) assertLogContains() bool {
 	logExpectations := c.expected.Log
 	result := true
 	if logExpectations.MatchRegex != "" {
-		result = c.log.Contains(logExpectations.MatchRegex)
+		result = c.log.MatchesRegex(logExpectations.MatchRegex)
 		if !result {
 			log.Debug().Msgf("Failed to find match for match_regex. Expected to find '%s'", logExpectations.MatchRegex)
 		}
 	}
 	if result && len(logExpectations.ExpectIds) > 0 {
-		result = c.log.Contains(generateIdRegex(logExpectations.ExpectIds))
-		if !result {
-			log.Debug().Msg("Failed to find expected IDs")
+		found, missedRules := c.log.ContainsAllIds(logExpectations.ExpectIds)
+		if !found {
+			log.Debug().Msgf("Failed to find the following IDs in the log: %v", missedRules)
+			result = false
 		}
 	}
+
 	return result
-}
-
-// Search for both standard ModSecurity, and JSON output
-func generateIdRegex(ids []uint) string {
-	modSecLogSyntax := strings.Builder{}
-	jsonLogSyntax := strings.Builder{}
-	modSecLogSyntax.WriteString(`\[id "(?:`)
-	jsonLogSyntax.WriteString(`"id":\s*"?(?:`)
-	for index, id := range ids {
-		if index > 0 {
-			modSecLogSyntax.WriteRune('|')
-			jsonLogSyntax.WriteRune('|')
-		}
-		modSecLogSyntax.WriteString(fmt.Sprint(id))
-		jsonLogSyntax.WriteString(fmt.Sprint(id))
-	}
-	modSecLogSyntax.WriteString(`)"\]`)
-	jsonLogSyntax.WriteString(`)"?`)
-
-	return modSecLogSyntax.String() + "|" + jsonLogSyntax.String()
 }

--- a/check/status_test.go
+++ b/check/status_test.go
@@ -4,8 +4,9 @@
 package check
 
 import (
-	"slices"
 	"testing"
+
+	"slices"
 
 	"github.com/stretchr/testify/suite"
 

--- a/config/types.go
+++ b/config/types.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	schema "github.com/coreruleset/ftw-tests-schema/types/overrides"
+
 	"github.com/coreruleset/go-ftw/ftwhttp"
 )
 

--- a/ftwhttp/client.go
+++ b/ftwhttp/client.go
@@ -13,10 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/rs/zerolog/log"
 	"golang.org/x/net/publicsuffix"
+	"golang.org/x/time/rate"
 )
 
 // NewClientConfig returns a new ClientConfig with reasonable defaults.

--- a/ftwhttp/client_test.go
+++ b/ftwhttp/client_test.go
@@ -11,9 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/time/rate"
 )
 
 const (

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/knadh/koanf/providers/rawbytes v0.1.0 h1:dpzgu2KO6uf6oCb4aP05KDmKmAmI
 github.com/knadh/koanf/providers/rawbytes v0.1.0/go.mod h1:mMTB1/IcJ/yE++A2iEZbY1MLygX7vttU+C+S/YmPu9c=
 github.com/knadh/koanf/v2 v2.1.1 h1:/R8eXqasSTsmDCsAyYj+81Wteg8AqrV9CP6gvsTsOmM=
 github.com/knadh/koanf/v2 v2.1.1/go.mod h1:4mnTRbZCK+ALuBXHZMjDfG9y714L7TykVnZkXbMU3Es=
-github.com/kyokomi/emoji/v2 v2.2.12 h1:sSVA5nH9ebR3Zji1o31wu3yOwD1zKXQA2z0zUyeit60=
-github.com/kyokomi/emoji/v2 v2.2.12/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/kyokomi/emoji/v2 v2.2.13 h1:GhTfQa67venUUvmleTNFnb+bi7S3aocF7ZCXU9fSO7U=
 github.com/kyokomi/emoji/v2 v2.2.13/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=

--- a/runner/run.go
+++ b/runner/run.go
@@ -9,12 +9,11 @@ import (
 	"regexp"
 	"time"
 
-	"golang.org/x/time/rate"
-
+	schema "github.com/coreruleset/ftw-tests-schema/types"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/time/rate"
 
-	schema "github.com/coreruleset/ftw-tests-schema/types"
 	"github.com/coreruleset/go-ftw/check"
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/ftwhttp"
@@ -271,7 +270,7 @@ func needToSkipTest(include *regexp.Regexp, exclude *regexp.Regexp, testCase *sc
 	}
 
 	result := false
-	// if we need to exclude tests, and the title matches,
+	// if we need to exclude tests, and the ID matches,
 	// it needs to be skipped
 	if exclude != nil {
 		if exclude.MatchString(testCase.IdString()) {
@@ -279,7 +278,7 @@ func needToSkipTest(include *regexp.Regexp, exclude *regexp.Regexp, testCase *sc
 		}
 	}
 
-	// if we need to include tests, but the title does not match
+	// if we need to include tests, but the ID does not match
 	// it needs to be skipped
 	if include != nil {
 		if !include.MatchString(testCase.IdString()) {

--- a/runner/stats.go
+++ b/runner/stats.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"time"
 
+	schema "github.com/coreruleset/ftw-tests-schema/types"
 	"github.com/rs/zerolog/log"
 
-	schema "github.com/coreruleset/ftw-tests-schema/types"
 	"github.com/coreruleset/go-ftw/output"
 )
 

--- a/test/defaults.go
+++ b/test/defaults.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 
 	schema "github.com/coreruleset/ftw-tests-schema/types"
+
 	"github.com/coreruleset/go-ftw/ftwhttp"
 	"github.com/coreruleset/go-ftw/utils"
 )

--- a/test/types.go
+++ b/test/types.go
@@ -5,14 +5,16 @@ package test
 
 import (
 	"regexp"
-	"slices"
 	"strconv"
+
+	"slices"
 
 	schema "github.com/coreruleset/ftw-tests-schema/types"
 	overridesSchema "github.com/coreruleset/ftw-tests-schema/types/overrides"
+	"github.com/rs/zerolog/log"
+
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/ftwhttp"
-	"github.com/rs/zerolog/log"
 )
 
 // ApplyInputOverride will check if config had global overrides and write that into the test.

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -258,11 +258,11 @@ func (s *readTestSuite) TestFTWLogLines_Contains() {
 			ll := &FTWLogLines{
 				logFile:             tt.fields.logFile,
 				LogMarkerHeaderName: bytes.ToLower(tt.fields.LogMarkerHeaderName),
-				StartMarker:         bytes.ToLower(tt.fields.StartMarker),
-				EndMarker:           bytes.ToLower(tt.fields.EndMarker),
 			}
-			got := ll.Contains(tt.args.match)
-			s.Equalf(tt.want, got, "Contains() = %v, want %v", got, tt.want)
+			ll.WithStartMarker(tt.fields.StartMarker)
+			ll.WithEndMarker(tt.fields.EndMarker)
+			got := ll.MatchesRegex(tt.args.match)
+			s.Equalf(tt.want, got, "MatchesRegex() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -323,10 +323,10 @@ func (s *readTestSuite) TestFTWLogLines_ContainsIn404() {
 			ll := &FTWLogLines{
 				logFile:             tt.fields.logFile,
 				LogMarkerHeaderName: bytes.ToLower(tt.fields.LogMarkerHeaderName),
-				StartMarker:         bytes.ToLower(tt.fields.StartMarker),
-				EndMarker:           bytes.ToLower(tt.fields.EndMarker),
 			}
-			got := ll.Contains(tt.args.match)
+			ll.WithStartMarker(tt.fields.StartMarker)
+			ll.WithEndMarker(tt.fields.EndMarker)
+			got := ll.MatchesRegex(tt.args.match)
 			s.Equalf(tt.want, got, "Contains() = %v, want %v", got, tt.want)
 		})
 	}
@@ -355,9 +355,9 @@ func (s *readTestSuite) TestFTWLogLines_CheckForLogMarkerIn404() {
 	ll := &FTWLogLines{
 		logFile:             log,
 		LogMarkerHeaderName: bytes.ToLower([]byte(cfg.LogMarkerHeaderName)),
-		StartMarker:         bytes.ToLower([]byte(markerLine)),
-		EndMarker:           bytes.ToLower([]byte(markerLine)),
 	}
+	ll.WithStartMarker([]byte(markerLine))
+	ll.WithEndMarker([]byte(markerLine))
 	foundMarker := ll.CheckLogForMarker(stageID, 100)
 	s.Equal(strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))
 }

--- a/waflog/types.go
+++ b/waflog/types.go
@@ -12,6 +12,23 @@ import (
 type FTWLogLines struct {
 	logFile             *os.File
 	LogMarkerHeaderName []byte
-	StartMarker         []byte
-	EndMarker           []byte
+	startMarker         []byte
+	endMarker           []byte
+	triggeredRules      []uint
+	markedLines         [][]byte
+}
+
+func (ll *FTWLogLines) StartMarker() []byte {
+	return ll.startMarker
+}
+
+func (ll *FTWLogLines) EndMarker() []byte {
+	return ll.endMarker
+}
+
+func (ll *FTWLogLines) reset() {
+	ll.startMarker = nil
+	ll.endMarker = nil
+	ll.triggeredRules = nil
+	ll.markedLines = nil
 }

--- a/waflog/waflog.go
+++ b/waflog/waflog.go
@@ -15,10 +15,7 @@ import (
 // NewFTWLogLines is the base struct for reading the log file
 func NewFTWLogLines(cfg *config.FTWConfiguration) (*FTWLogLines, error) {
 	ll := &FTWLogLines{
-		logFile:             nil,
 		LogMarkerHeaderName: bytes.ToLower([]byte(cfg.LogMarkerHeaderName)),
-		StartMarker:         nil,
-		EndMarker:           nil,
 	}
 
 	if err := ll.openLogFile(cfg); err != nil {
@@ -32,14 +29,15 @@ func NewFTWLogLines(cfg *config.FTWConfiguration) (*FTWLogLines, error) {
 	return ll, nil
 }
 
-// WithStartMarker sets the start marker for the log file
+// WithStartMarker resets the internal state of the log file checker and sets the start marker for the log file
 func (ll *FTWLogLines) WithStartMarker(marker []byte) {
-	ll.StartMarker = bytes.ToLower(marker)
+	ll.reset()
+	ll.startMarker = bytes.ToLower(marker)
 }
 
 // WithEndMarker sets the end marker for the log file
 func (ll *FTWLogLines) WithEndMarker(marker []byte) {
-	ll.EndMarker = bytes.ToLower(marker)
+	ll.endMarker = bytes.ToLower(marker)
 }
 
 // Cleanup closes the log file

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -4,6 +4,7 @@
 package waflog
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -32,4 +33,44 @@ func (s *waflogTestSuite) TestNewFTWLogLines() {
 	s.NotNil(ll.EndMarker, "Failed! EndMarker must be set")
 	err := ll.Cleanup()
 	s.Require().NoError(err)
+}
+
+func (s *waflogTestSuite) TestWithStartMarker() {
+	cfg := config.NewDefaultConfig()
+	s.NotNil(cfg)
+
+	// Don't call NewFTWLogLines to avoid opening the file.
+	ll := &FTWLogLines{}
+	ll.WithStartMarker([]byte("#"))
+	ll.WithEndMarker([]byte("#"))
+
+	s.NotNil(ll.StartMarker())
+	s.NotNil(ll.EndMarker())
+
+	ll.WithStartMarker([]byte("new"))
+	s.Nil(ll.endMarker, "WithStartMarker should reset end marker")
+
+	ll.WithEndMarker([]byte("newer"))
+	s.Equal("new", string(ll.startMarker))
+	s.Equal("newer", string(ll.endMarker))
+}
+
+func (s *waflogTestSuite) TestLogLinesReset() {
+	ll := FTWLogLines{
+		logFile:             &os.File{},
+		LogMarkerHeaderName: []byte("X-Tests"),
+		startMarker:         []byte("startmarker"),
+		endMarker:           []byte("endmarker"),
+		triggeredRules:      []uint{1, 3, 3},
+		markedLines:         [][]byte{[]byte("line1"), []byte("line2")},
+	}
+
+	ll.reset()
+	s.IsType(&os.File{}, ll.logFile)
+	s.Equal("X-Tests", string(ll.LogMarkerHeaderName))
+	s.Nil(ll.startMarker)
+	s.Nil(ll.endMarker)
+	s.Nil(ll.triggeredRules)
+	s.Nil(ll.triggeredRules)
+	s.Nil(ll.markedLines)
 }


### PR DESCRIPTION
The implementation for positive match of a list of IDs only required a single ID to match instead of all.

This commit also introduces memoization to minimize IO when searching the log.

Also fixed pre-commit config.