### PR TITLE
fix: broken tests and RunTest on windows

### DIFF
--- a/check/base.go
+++ b/check/base.go
@@ -111,3 +111,7 @@ func (c *FTWCheck) SetStartMarker(marker []byte) {
 func (c *FTWCheck) SetEndMarker(marker []byte) {
 	c.log.WithEndMarker(marker)
 }
+
+func (c *FTWCheck) Close() error {
+	return c.log.Cleanup()
+}

--- a/check/logs_test.go
+++ b/check/logs_test.go
@@ -4,7 +4,6 @@
 package check
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -50,7 +49,7 @@ func (s *checkLogsTestSuite) SetupTest() {
 }
 
 func (s *checkLogsTestSuite) TearDownTest() {
-	err := os.Remove(s.logName)
+	err := s.check.Close()
 	s.Require().NoError(err)
 }
 

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -51,6 +51,8 @@ func (s *checkCmdTestSuite) SetupTest() {
 	s.Require().NoError(err)
 	n, err := testFileContents.WriteString(checkFileContents)
 	s.Require().NoError(err)
+	err = testFileContents.Close()
+	s.Require().NoError(err)
 	s.Equal(len(checkFileContents), n)
 
 	s.rootCmd = NewRootCommand()

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -84,6 +84,8 @@ func (s *runCmdTestSuite) SetupTest() {
 	s.Require().NoError(err)
 	err = tmpl.Execute(testFileContents, vars)
 	s.Require().NoError(err)
+	err = testFileContents.Close()
+	s.Require().NoError(err)
 
 	s.rootCmd = NewRootCommand()
 	s.rootCmd.AddCommand(NewRunCommand())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -256,6 +256,7 @@ func (s *baseTestSuite) TestLoadPlatformOverrides() {
 	tempDir := s.T().TempDir()
 	overridesFile, err := os.CreateTemp(tempDir, "overrides.yaml")
 	s.Require().NoError(err)
+	defer overridesFile.Close()
 	_, err = overridesFile.WriteString(`---
 version: "v0.0.0"
 meta:

--- a/runner/run.go
+++ b/runner/run.go
@@ -104,6 +104,7 @@ func RunTest(runContext *TestRunContext, ftwTest *test.FTWTest) error {
 			if err != nil {
 				return err
 			}
+			defer ftwCheck.Close()
 			if err := RunStage(runContext, ftwCheck, testCase, stage); err != nil {
 				if err.Error() == "retry-once" {
 					log.Info().Msgf("Retrying test once: %s", testCase.IdString())

--- a/runner/run_cloud_test.go
+++ b/runner/run_cloud_test.go
@@ -72,10 +72,14 @@ func (s *runCloudTestSuite) BeforeTest(_ string, name string) {
 	tmpl, err := template.ParseFiles(fmt.Sprintf("testdata/%s.yaml", name))
 	s.Require().NoError(err)
 	// create a temporary file to hold the test
-	testFileContents, err := os.CreateTemp("testdata", "mock-test-*.yaml")
+	testdataDir, err := os.MkdirTemp(s.Suite.T().TempDir(), "testdata")
+	s.Require().NoError(err)
+	testFileContents, err := os.CreateTemp(testdataDir, "mock-test-*.yaml")
 	s.Require().NoError(err, "cannot create temporary file")
 	err = tmpl.Execute(testFileContents, vars)
 	s.Require().NoError(err, "cannot execute template")
+	err = testFileContents.Close()
+	s.Require().NoError(err)
 	// get tests from file
 	s.ftwTests, err = test.GetTestsFromFiles(testFileContents.Name())
 	s.Require().NoError(err, "cannot get tests from file")

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -143,7 +143,9 @@ func (s *runTestSuite) setUpLogFileForTestServer() {
 	}
 	// if no file has been configured, create one and handle cleanup
 	if s.logFilePath == "" {
-		file, err := os.CreateTemp("", "go-ftw-test-*.log")
+		file, err := os.CreateTemp(s.T().TempDir(), "go-ftw-test-*.log")
+		s.Require().NoError(err)
+		err = file.Close()
 		s.Require().NoError(err)
 		s.logFilePath = file.Name()
 	}
@@ -239,6 +241,8 @@ func (s *runTestSuite) BeforeTest(_ string, name string) {
 	s.Require().NoError(err, "cannot create temporary file")
 	err = tmpl.Execute(testFileContents, vars)
 	s.Require().NoError(err, "cannot execute template")
+	err = testFileContents.Close()
+	s.Require().NoError(err)
 	// get tests from file
 	s.ftwTests, err = test.GetTestsFromFiles(testFileContents.Name())
 	s.Require().NoError(err, "cannot get tests from file")


### PR DESCRIPTION
This fixes all broken tests and RunTest/FTWCheck on windows, by properly closing opened files.

Windows refuses to delete files as long as a file descriptor is open. Closing the temporary files in the tests and closing the log files opened by FTWCheck in RunTest fixes these issues.

Closes  #349