### PR TITLE
chore: adds single quote boundaries when printing strings in logs

### DIFF
--- a/test/types.go
+++ b/test/types.go
@@ -8,10 +8,11 @@ import (
 	"regexp"
 	"strconv"
 
+	"slices"
+
 	schema "github.com/coreruleset/ftw-tests-schema/v2/types"
 	overridesSchema "github.com/coreruleset/ftw-tests-schema/v2/types/overrides"
 	"github.com/rs/zerolog/log"
-	"slices"
 
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/ftwhttp"
@@ -32,7 +33,7 @@ func ApplyInputOverrides(conf *config.FTWConfiguration, input *Input) {
 
 func ApplyPlatformOverrides(conf *config.FTWConfiguration, testCase *schema.Test) {
 	platformOverrides := conf.PlatformOverrides
-	log.Debug().Msgf("Applying overrides for engine '%s', platform '%s", platformOverrides.Meta.Engine, platformOverrides.Meta.Platform)
+	log.Debug().Msgf("Applying overrides for engine '%s', platform '%s'", platformOverrides.Meta.Engine, platformOverrides.Meta.Platform)
 	overrides, ok := platformOverrides.OverridesMap[testCase.RuleId]
 	if !ok {
 		log.Trace().Msgf("no override found for rule %d", testCase.RuleId)

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -10,9 +10,10 @@ import (
 	"regexp"
 	"strconv"
 
+	"slices"
+
 	"github.com/icza/backscanner"
 	"github.com/rs/zerolog/log"
-	"slices"
 )
 
 const maxRuleIdsEstimate = 15
@@ -29,10 +30,10 @@ func (ll *FTWLogLines) TriggeredRules() []uint {
 	lines := ll.getMarkedLines()
 	regex := regexp.MustCompile(`\[id "(\d+)"\]|"id":\s*"?(\d+)"?`)
 	for _, line := range lines {
-		log.Trace().Msgf("ftw/waflog: Looking for any rule in %s", line)
+		log.Trace().Msgf("ftw/waflog: Looking for any rule in '%s'", line)
 		match := regex.FindAllSubmatch(line, -1)
 		if match != nil {
-			log.Trace().Msgf("ftw/waflog: Found %s at %s", regex.String(), line)
+			log.Trace().Msgf("ftw/waflog: Found '%s' at '%s'", regex.String(), line)
 			for _, nextMatch := range match {
 				for index := 1; index <= 2; index++ {
 					submatchBytes := nextMatch[index]
@@ -102,13 +103,13 @@ func (ll *FTWLogLines) MatchesRegex(pattern string) bool {
 
 	result := false
 	for _, line := range lines {
-		log.Trace().Msgf("ftw/waflog: Matching %s in %s", pattern, line)
+		log.Trace().Msgf("ftw/waflog: Matching '%s' in '%s'", pattern, line)
 		found, err := regexp.Match(pattern, line)
 		if err != nil {
 			log.Fatal().Msgf("ftw/waflog: bad regexp %s", err.Error())
 		}
 		if found {
-			log.Trace().Msgf("ftw/waflog: Found %s at %s", pattern, line)
+			log.Trace().Msgf("ftw/waflog: Found '%s' at '%s'", pattern, line)
 			result = true
 			break
 		}


### PR DESCRIPTION
Nits about logs printed at debug/trace levels. It helps a bit more understanding the logs when strings are empty, or with whitespace chars. I would even go with `%q`, but I kept the single quotes format present in other logs.