### PR TITLE
quantitative: runs with `DetectionOnly`, fixes `--payload`

### DIFF
--- a/cmd/quantitative.go
+++ b/cmd/quantitative.go
@@ -18,10 +18,11 @@ import (
 // Returns a new cobra command for running quantitative tests
 func NewQuantitativeCmd() *cobra.Command {
 	runCmd := &cobra.Command{
-		Use:   "quantitative",
-		Short: "Run quantitative tests",
-		Long:  `Run all quantitative tests`,
-		RunE:  runQuantitativeE,
+		Use:     "quantitative",
+		Aliases: []string{"q"},
+		Short:   "Run quantitative tests",
+		Long:    `Run all quantitative tests`,
+		RunE:    runQuantitativeE,
 	}
 
 	runCmd.Flags().IntP("lines", "l", 0, "Number of lines of input to process before stopping")

--- a/internal/quantitative/local_engine_test.go
+++ b/internal/quantitative/local_engine_test.go
@@ -5,7 +5,6 @@ package quantitative
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path"
 	"testing"
@@ -59,13 +58,11 @@ func (s *localEngineTestSuite) TestCrsCall() {
 	s.Require().NotNil(s.engine)
 
 	// simple payload, no matches
-	status, matchedRules := s.engine.CrsCall("this is a test")
-	s.Require().Equal(http.StatusOK, status)
+	matchedRules := s.engine.CrsCall("this is a test")
 	s.Require().Empty(matchedRules)
 
 	// this payload will match a few rules
-	status, matchedRules = s.engine.CrsCall("' OR 1 = 1")
-	s.Require().Equal(http.StatusForbidden, status)
+	matchedRules = s.engine.CrsCall("' OR 1 = 1")
 	s.Require().NotEmpty(matchedRules)
 
 	expected := []int{942100 /* libinjection match */}

--- a/internal/quantitative/runner.go
+++ b/internal/quantitative/runner.go
@@ -66,6 +66,7 @@ func RunQuantitativeTests(params Params, out *output.Output) error {
 			return err
 		}
 		p.SetContent(params.Payload)
+		stats.incrementRun()
 		// CrsCall with payload
 		doEngineCall(runner, p, params.Rule, stats)
 

--- a/internal/quantitative/runner_test.go
+++ b/internal/quantitative/runner_test.go
@@ -71,6 +71,8 @@ func (s *runnerTestSuite) TestCorpusFactory() {
 }
 
 func (s *runnerTestSuite) TestRunQuantitative() {
+	// This test is expecting to have at least one rule false positive in the used corpus
+	// If it is not anymore the case, an option could be to use a different corpus language
 	s.Run("with corpus", func() {
 		var b bytes.Buffer
 		out := output.NewOutput("plain", &b)
@@ -79,8 +81,6 @@ func (s *runnerTestSuite) TestRunQuantitative() {
 		s.Require().NoError(err)
 	})
 
-	// This test is expecting to have at least one rule false positive in the used corpus
-	// If it is not anymore the case, an option could be to use a different corpus language
 	s.Run("with payload", func() {
 		s.params.Payload = "<script>alert('0')</script>"
 		s.params.Rule = 0 // Default rule, we don't want to check only a specific rule

--- a/internal/quantitative/runner_test.go
+++ b/internal/quantitative/runner_test.go
@@ -70,22 +70,24 @@ func (s *runnerTestSuite) TestCorpusFactory() {
 	s.Require().Error(err)
 }
 
-// This test is expecting to have at least one rule false positive in the used corpus
-// If it is not anymore the case, an option could be to use a different corpus language
-func (s *runnerTestSuite) TestRunQuantitativeTestsWithCorpus() {
-	var b bytes.Buffer
-	out := output.NewOutput("plain", &b)
-	err := RunQuantitativeTests(s.params, out)
-	s.Require().Contains(b.String(), "false positives")
-	s.Require().NoError(err)
-}
+func (s *runnerTestSuite) TestRunQuantitative() {
+	s.Run("with corpus", func() {
+		var b bytes.Buffer
+		out := output.NewOutput("plain", &b)
+		err := RunQuantitativeTests(s.params, out)
+		s.Require().Contains(b.String(), "false positives")
+		s.Require().NoError(err)
+	})
 
-func (s *runnerTestSuite) TestRunQuantitativeTestsWithPayload() {
-	s.params.Payload = "<script>alert('0')</script>"
-	s.params.Rule = 0 // Default rule, we don't want to check only a specific rule
-	var b bytes.Buffer
-	out := output.NewOutput("plain", &b)
-	err := RunQuantitativeTests(s.params, out)
-	s.Require().NoError(err)
-	s.Require().Contains(b.String(), "1 false positives")
+	// This test is expecting to have at least one rule false positive in the used corpus
+	// If it is not anymore the case, an option could be to use a different corpus language
+	s.Run("with payload", func() {
+		s.params.Payload = "<script>alert('0')</script>"
+		s.params.Rule = 0 // Default rule, we don't want to check only a specific rule
+		var b bytes.Buffer
+		out := output.NewOutput("plain", &b)
+		err := RunQuantitativeTests(s.params, out)
+		s.Require().NoError(err)
+		s.Require().Contains(b.String(), "1 false positives")
+	})
 }

--- a/internal/quantitative/runner_test.go
+++ b/internal/quantitative/runner_test.go
@@ -33,7 +33,6 @@ func (s *runnerTestSuite) SetupTest() {
 		Lines:         1000,
 		Fast:          10,
 		Rule:          1000,
-		Payload:       "test",
 		Number:        1000,
 		Directory:     path.Join(s.dir, fmt.Sprintf("coreruleset-%s", crsTestVersion)),
 		ParanoiaLevel: 1,
@@ -71,9 +70,22 @@ func (s *runnerTestSuite) TestCorpusFactory() {
 	s.Require().Error(err)
 }
 
-func (s *runnerTestSuite) TestRunQuantitativeTests() {
+// This test is expecting to have at least one rule false positive in the used corpus
+// If it is not anymore the case, an option could be to use a different corpus language
+func (s *runnerTestSuite) TestRunQuantitativeTestsWithCorpus() {
+	var b bytes.Buffer
+	out := output.NewOutput("plain", &b)
+	err := RunQuantitativeTests(s.params, out)
+	s.Require().Contains(b.String(), "false positives")
+	s.Require().NoError(err)
+}
+
+func (s *runnerTestSuite) TestRunQuantitativeTestsWithPayload() {
+	s.params.Payload = "<script>alert('0')</script>"
+	s.params.Rule = 0 // Default rule, we don't want to check only a specific rule
 	var b bytes.Buffer
 	out := output.NewOutput("plain", &b)
 	err := RunQuantitativeTests(s.params, out)
 	s.Require().NoError(err)
+	s.Require().Contains(b.String(), "1 false positives")
 }

--- a/internal/quantitative/runner_test.go
+++ b/internal/quantitative/runner_test.go
@@ -83,7 +83,7 @@ func (s *runnerTestSuite) TestRunQuantitative() {
 
 	s.Run("with payload", func() {
 		s.params.Payload = "<script>alert('0')</script>"
-		s.params.Rule = 0 // Default rule, we don't want to check only a specific rule
+		s.params.Rule = 0 // Reset the field, we don't want to check only a specific rule
 		var b bytes.Buffer
 		out := output.NewOutput("plain", &b)
 		err := RunQuantitativeTests(s.params, out)


### PR DESCRIPTION
- Adds `q` as `quantitative` alias
- Runs quantitative testing with `DetectionOnly`: detection is not interrupted anymore if phase 1 rules match.
- code Refactor to better fit providing the `--payload` parameter
- Fixes `--payload`