### PR TITLE
fix: create output file if it does not exist

### DIFF
--- a/cmd/quantitative.go
+++ b/cmd/quantitative.go
@@ -78,7 +78,7 @@ func runQuantitativeE(cmd *cobra.Command, _ []string) error {
 	if outputFilename == "" {
 		outputFile = os.Stdout
 	} else {
-		outputFile, err = os.Open(outputFilename)
+		outputFile, err = os.OpenFile(outputFilename, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {
 			return err
 		}

--- a/internal/quantitative/runner.go
+++ b/internal/quantitative/runner.go
@@ -47,7 +47,7 @@ type Params struct {
 // RunQuantitativeTests runs all quantitative tests
 func RunQuantitativeTests(params Params, out *output.Output) error {
 	var lc corpus.File
-	out.Println(":hourglass: Running quantitative tests with %d goroutines", params.MaxConcurrency)
+	log.Info().Msgf("⏳Running quantitative tests with %d goroutines", params.MaxConcurrency)
 	log.Trace().Msgf("Rule: %d", params.Rule)
 	log.Trace().Msgf("Payload: %s", params.Payload)
 	log.Trace().Msgf("Directory: %s", params.Directory)


### PR DESCRIPTION
## what

- create the file if it doesn't exist

## why

- the file doesn't need to exist beforehand