### PR TITLE
feat: rename `buildRequest` to `BuildRequest` to make it exported

### DIFF
--- a/ftwhttp/connection.go
+++ b/ftwhttp/connection.go
@@ -84,7 +84,7 @@ func (c *Connection) receive() (io.Reader, error) {
 // Request will use all the inputs and send a raw http request to the destination
 func (c *Connection) Request(request *Request) error {
 	// Build request first, then connect and send, so timers are accurate
-	data, err := buildRequest(request)
+	data, err := BuildRequest(request)
 	if err != nil {
 		return fmt.Errorf("ftw/http: fatal error building request: %w", err)
 	}

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -127,7 +127,7 @@ func (r Request) isRaw() bool {
 }
 
 // The request should be created with anything we want. We want to actually break HTTP.
-func buildRequest(r *Request) ([]byte, error) {
+func BuildRequest(r *Request) ([]byte, error) {
 	var err error
 	var b bytes.Buffer
 	var data []byte


### PR DESCRIPTION
I'm aiming to import the ftwhttp package into another Go project and call the `buildRequest` function directly. However, since `buildRequest` is unexported (lowercased), it’s inaccessible from outside the package.

Renaming `buildRequest` to `BuildRequest` would make it an exported function, allowing me to use it outside of go-ftw