### PR TITLE
Extend ID Regex to support escaped quotes

### DIFF
--- a/waflog/read.go
+++ b/waflog/read.go
@@ -28,7 +28,7 @@ func (ll *FTWLogLines) TriggeredRules() []uint {
 	ll.triggeredRulesInitialized = true
 
 	lines := ll.getMarkedLines()
-	regex := regexp.MustCompile(`\[id "(\d+)"\]|"id":\s*"?(\d+)"?`)
+	regex := regexp.MustCompile(`\[id \\?"(\d+)\\?"\]|"id":\s*"?(\d+)"?`)
 	for _, line := range lines {
 		log.Trace().Msgf("ftw/waflog: Looking for any rule in '%s'", line)
 		match := regex.FindAllSubmatch(line, -1)

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -28,6 +28,14 @@ func (ll *FTWLogLines) TriggeredRules() []uint {
 	ll.triggeredRulesInitialized = true
 
 	lines := ll.getMarkedLines()
+
+	// This regex provides flexibility in parsing how the rule ID is logged.
+	// `\[id \\?"(\d+)\\?"\]` supports:
+	//	- [id "999999"]
+	//	- [id \"999999\"] (escaped quotes)
+	// `"id":\s*"?(\d+)"?` supports:
+	//	- ["id":"999999"]
+	//	- {"id":4}
 	regex := regexp.MustCompile(`\[id \\?"(\d+)\\?"\]|"id":\s*"?(\d+)"?`)
 	for _, line := range lines {
 		log.Trace().Msgf("ftw/waflog: Looking for any rule in '%s'", line)

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -371,11 +371,11 @@ func (s *readTestSuite) TestFindAllIdsInLogs() {
 	markerLine := "X-cRs-TeSt: " + stageID
 	logLines := fmt.Sprint("\n", markerLine,
 		`[id "1"] something else [id "2"]`,
-		`"id": 3, something else {"id":4}`+"\n",
+		`"id": 3, something else {"id":4},`,
+		`something else [id \"5\"]`+"\n",
 		"\n", markerLine)
 	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
 	s.Require().NoError(err)
-
 	cfg.LogFile = filename
 	log, err := os.Open(filename)
 	s.Require().NoError(err)
@@ -388,9 +388,10 @@ func (s *readTestSuite) TestFindAllIdsInLogs() {
 	ll.WithEndMarker([]byte(markerLine))
 
 	foundRuleIds := ll.TriggeredRules()
-	s.Len(foundRuleIds, 4)
+	s.Len(foundRuleIds, 5)
 	s.Contains(foundRuleIds, uint(1))
 	s.Contains(foundRuleIds, uint(2))
 	s.Contains(foundRuleIds, uint(3))
 	s.Contains(foundRuleIds, uint(4))
+	s.Contains(foundRuleIds, uint(5))
 }


### PR DESCRIPTION
Address https://github.com/coreruleset/coreruleset/issues/3239.
This PR proposes to extend the regex looking for IDs to support also IDs coming with escaped quotes.
JSON log lines such as the following one are not supported:
```
{"time":"2024-12-06T11:13:12.250069+01:00","level":"ERROR","msg":"[client \"127.0.0.1\"] Coraza: Warning. Request content type charset is not allowed by policy [file \"@owasp_crs/REQUEST-920-PROTOCOL-ENFORCEMENT.conf\"] [line \"2753\"] [id \"920480\"] [rev \"\"] [msg \"Request content type charset is not allowed by policy\"] [data \"|garbage|\"] [severity \"critical\"] [ver \"OWASP_CRS/4.7.0\"] [maturity \"0\"] [accuracy \"0\"] [tag \"application-multi\"] [tag \"language-multi\"] [tag \"platform-multi\"] [tag \"attack-protocol\"] [tag \"paranoia-level/1\"] [tag \"OWASP_CRS\"] [tag \"capec/1000/255/153\"] [tag \"PCI/12.1\"] [hostname \"127.0.0.1\"] [uri \"/\"] [unique_id \"UGAYIvYnOAtQVNqhxNg\"]","severity":"critical"}
```
As described in the original issue, the problem is `[id \"920480\"]`, but now as mentioned in https://github.com/coreruleset/coreruleset/issues/3239#issuecomment-2096775153, we can just extend the regex to make it flexible enough to support also this case.