### PR TITLE
fix: flaky results: same start and end marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ And a sample code:
     cfg.TestOverride.Input.DestAddr = &host
     cfg.TestOverride.Input.Port = &port
 
-    res, err := runner.Run(cfg, tests, runner.RunnerConfig{
+    res, err := runner.Run(cfg, tests, &runner.RunnerConfig{
                     ShowTime: false,
                     }, output.NewOutput("quiet", os.Stdout))
     if err != nil {

--- a/check/base.go
+++ b/check/base.go
@@ -116,6 +116,10 @@ func (c *FTWCheck) GetTriggeredRules() []uint {
 	if c.CloudMode() {
 		return nil
 	}
+	// When a test is expecting to trigger an error and it effectively does, markers are not set.
+	if len(c.log.StartMarker()) == 0 || len(c.log.EndMarker()) == 0 {
+		return nil
+	}
 	return c.log.TriggeredRules()
 }
 

--- a/check/logs_test.go
+++ b/check/logs_test.go
@@ -6,18 +6,24 @@ package check
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/coreruleset/go-ftw/config"
 	"github.com/coreruleset/go-ftw/utils"
 )
 
-var logText = `[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
+var (
+	uuidString  = "8677f1ed-3936-4999-82e4-39daf32ffff5"
+	markerStart = uuidString + "-s"
+	markerEnd   = uuidString + "-e"
+	logText     = markerStart +
+		`
+[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 [Tue Jan 05 02:21:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id "920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 [Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 [Tue Jan 05 02:21:09.647668 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:inbound_anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/RESPONSE-980-CORRELATION.conf"] [line "87"] [id "980130"] [msg "Inbound Anomaly Score Exceeded (Total Inbound Score: 5 - SQLI=0,XSS=0,RFI=0,LFI=0,RCE=0,PHPI=0,HTTP=0,SESS=0): individual paranoia level scores: 3, 2, 0, 0"] [ver "OWASP_CRS/3.3.0"] [tag "event-correlation"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
-`
+` + markerEnd
+)
 
 type checkLogsTestSuite struct {
 	suite.Suite
@@ -41,11 +47,8 @@ func (s *checkLogsTestSuite) SetupTest() {
 	s.check, err = NewCheck(s.cfg)
 	s.Require().NoError(err)
 
-	// The log checker requires the markers to be set, but
-	// for these tests we can set them to random strings because
-	// we just check all lines.
-	s.check.log.WithStartMarker([]byte(uuid.NewString()))
-	s.check.log.WithEndMarker([]byte(uuid.NewString()))
+	s.check.log.WithStartMarker([]byte(markerStart))
+	s.check.log.WithEndMarker([]byte(markerEnd))
 }
 
 func (s *checkLogsTestSuite) TearDownTest() {

--- a/runner/run.go
+++ b/runner/run.go
@@ -165,6 +165,7 @@ func RunStage(runContext *TestRunContext, ftwCheck *check.FTWCheck, testCase sch
 		Port:     testInput.GetPort(),
 		Protocol: testInput.GetProtocol(),
 	}
+
 	var startMarker []byte
 	if notRunningInCloudMode(ftwCheck) {
 		var err error

--- a/runner/run.go
+++ b/runner/run.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	// start and end UUID suffixes are used to disambiguate start and end markers.
-	// It permits to make the markers unique, while still maintaining one UUID per stage.
+	// Start and end UUID suffixes are used to disambiguate start and end markers.
+	// The suffixes make the markers unique, while still maintaining one UUID per stage.
 	startUuidSuffix = "-s"
 	endUuidSuffix   = "-e"
 )

--- a/runner/run.go
+++ b/runner/run.go
@@ -26,8 +26,8 @@ import (
 const (
 	// start and end UUID suffixes are used to disambiguate start and end markers.
 	// It permits to make the markers unique, while still maintaining one UUID per stage.
-	startUUIDSuffix = "-s"
-	endUUIDSuffix   = "-e"
+	startUuidSuffix = "-s"
+	endUuidSuffix   = "-e"
 )
 
 // Run runs your tests with the specified Config.
@@ -174,8 +174,8 @@ func RunStage(runContext *TestRunContext, ftwCheck *check.FTWCheck, testCase sch
 	}
 
 	if notRunningInCloudMode(ftwCheck) {
-		startUUID := stageId + startUUIDSuffix
-		startMarker, err := markAndFlush(runContext, &testInput, startUUID)
+		startId := stageId + startUuidSuffix
+		startMarker, err := markAndFlush(runContext, &testInput, startId)
 		if err != nil && !expectErr {
 			return fmt.Errorf("failed to find start marker: %w", err)
 		}
@@ -202,8 +202,8 @@ func RunStage(runContext *TestRunContext, ftwCheck *check.FTWCheck, testCase sch
 	}
 
 	if notRunningInCloudMode(ftwCheck) {
-		endUUID := stageId + endUUIDSuffix
-		endMarker, err := markAndFlush(runContext, &testInput, endUUID)
+		endId := stageId + endUuidSuffix
+		endMarker, err := markAndFlush(runContext, &testInput, endId)
 		if err != nil && !expectErr {
 			return fmt.Errorf("failed to find end marker: %w", err)
 

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -172,7 +172,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 		lineLower := bytes.ToLower(line)
 
 		if !endFound {
-			// Skip lines until we find the end marker. Reading backwards, the line we are looking for are
+			// Skip lines until we find the end marker. Reading backwards, the lines we are looking for are
 			// between the end and start markers.
 			if bytes.Equal(lineLower, ll.endMarker) {
 				endFound = true
@@ -189,20 +189,19 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 		ll.markedLines = append(ll.markedLines, saneCopy)
 	}
 	if !startFound {
-		log.Debug().Msgf("starter marker not found while getting marked lines")
+		log.Debug().Msg("starter marker not found while getting marked lines")
 	}
 
 	return ll.markedLines
 }
 
 // CheckLogForMarker reads the log file and searches for a marker line.
-// stageID is the ID of the current stage, which is part of the marker line
-// At this point, stageID includes also the start or end suffix.
+// markerId is the ID of the current stage + suffix (for start / end), which is part of the marker line
 // readLimit is the maximum numbers of lines to check
-func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit uint) []byte {
+func (ll *FTWLogLines) CheckLogForMarker(markerId string, readLimit uint) []byte {
 	offset, err := ll.logFile.Seek(0, io.SeekEnd)
 	if err != nil {
-		log.Error().Caller().Err(err).Msgf("failed to seek end of log file")
+		log.Error().Caller().Err(err).Msg("failed to seek end of log file")
 		return nil
 	}
 
@@ -211,7 +210,7 @@ func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit uint) []byte 
 		ChunkSize: 4096,
 	}
 	scanner := backscanner.NewOptions(ll.logFile, int(offset), backscannerOptions)
-	stageIDBytes := []byte(stageID)
+	stageIDBytes := []byte(markerId)
 	crsHeaderBytes := bytes.ToLower([]byte(ll.LogMarkerHeaderName))
 
 	var line []byte
@@ -245,6 +244,6 @@ func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit uint) []byte 
 	if bytes.Contains(line, stageIDBytes) {
 		return line
 	}
-	log.Debug().Msgf("found unexpected marker line while looking for %s: %s", stageID, line)
+	log.Debug().Msgf("found unexpected marker line while looking for %s: %s", markerId, line)
 	return nil
 }

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -173,6 +173,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 			continue
 		}
 		if endFound && bytes.Equal(lineLower, ll.startMarker) {
+			startFound = true
 			break
 		}
 

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -189,7 +189,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 		ll.markedLines = append(ll.markedLines, saneCopy)
 	}
 	if !startFound {
-		log.Debug().Msg("starter marker not found while getting marked lines")
+		log.Debug().Msg("start marker not found while collecting marked lines")
 	}
 
 	return ll.markedLines

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -143,6 +143,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 	if ll.startMarker == nil || ll.endMarker == nil {
 		log.Fatal().Msg("Both start and end marker must be set before the log can be inspected")
 	}
+
 	fi, err := ll.logFile.Stat()
 	if err != nil {
 		log.Error().Caller().Msgf("cannot read file's size")

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -138,12 +138,12 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 	}
 	ll.markedLinesInitialized = true
 
-	if ll.startMarker == nil || ll.endMarker == nil {
+	if len(ll.startMarker) == 0 || len(ll.endMarker) == 0 {
 		log.Fatal().Msg("Both start and end marker must be set before the log can be inspected")
 	}
 
 	if bytes.Equal(ll.startMarker, ll.endMarker) {
-		log.Fatal().Msg("Start and end markers must be different")
+		log.Fatal().Msgf("Start and end markers must be different. %q", ll.startMarker)
 	}
 
 	fi, err := ll.logFile.Stat()

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -148,7 +148,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 
 	fi, err := ll.logFile.Stat()
 	if err != nil {
-		log.Error().Caller().Msgf("cannot read file's size")
+		log.Error().Caller().Msg("cannot read file's size")
 		return ll.markedLines
 	}
 

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -200,7 +200,6 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 // At this point, stageID includes also the start or end suffix.
 // readLimit is the maximum numbers of lines to check
 func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit uint) []byte {
-	var line []byte
 	offset, err := ll.logFile.Seek(0, io.SeekEnd)
 	if err != nil {
 		log.Error().Caller().Err(err).Msgf("failed to seek end of log file")
@@ -215,6 +214,7 @@ func (ll *FTWLogLines) CheckLogForMarker(stageID string, readLimit uint) []byte 
 	stageIDBytes := []byte(stageID)
 	crsHeaderBytes := bytes.ToLower([]byte(ll.LogMarkerHeaderName))
 
+	var line []byte
 	lineCounter := uint(0)
 	// Look for the header until EOF or `readLimit` lines at most
 	for {

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -170,10 +170,7 @@ func (ll *FTWLogLines) getMarkedLines() [][]byte {
 			break
 		}
 		lineLower := bytes.ToLower(line)
-		if !endFound && bytes.Equal(lineLower, ll.endMarker) {
-			endFound = true
-			continue
-		}
+
 		if !endFound {
 			// Skip lines until we find the end marker. Reading backwards, the line we are looking for are
 			// between the end and start markers.

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -34,8 +34,8 @@ func (s *readTestSuite) TestReadCheckLogForMarkerNoMarkerAtEnd() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	markerLine := "X-cRs-TeSt: " + stageID
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLine := "X-cRs-TeSt: " + stageId
 	logLines := `
 [Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 ` + markerLine + `
@@ -50,7 +50,7 @@ func (s *readTestSuite) TestReadCheckLogForMarkerNoMarkerAtEnd() {
 	ll, err := NewFTWLogLines(cfg)
 	s.Require().NoError(err)
 	ll.WithStartMarker([]byte(markerLine))
-	marker := ll.CheckLogForMarker(stageID, 100)
+	marker := ll.CheckLogForMarker(stageId, 100)
 	s.Equal(string(marker), strings.ToLower(markerLine), "unexpectedly found marker")
 }
 
@@ -59,8 +59,8 @@ func (s *readTestSuite) TestReadCheckLogForMarkerWithMarkerAtEnd() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	markerLine := "X-cRs-TeSt: " + stageID
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLine := "X-cRs-TeSt: " + stageId
 	logLines := `
 [Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 [Tue Jan 05 02:21:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id "920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
@@ -75,7 +75,7 @@ func (s *readTestSuite) TestReadCheckLogForMarkerWithMarkerAtEnd() {
 	ll.WithStartMarker([]byte(markerLine))
 	s.Require().NoError(err)
 
-	marker := ll.CheckLogForMarker(stageID, 100)
+	marker := ll.CheckLogForMarker(stageId, 100)
 	s.NotNil(marker, "no marker found")
 
 	s.Equal(marker, bytes.ToLower([]byte(markerLine)), "found unexpected marker")
@@ -86,9 +86,9 @@ func (s *readTestSuite) TestReadGetMarkedLines() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	startMarkerLine := "X-cRs-TeSt: " + stageID + " -start"
-	endMarkerLine := "X-cRs-TeSt: " + stageID + " -end"
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	startMarkerLine := "X-cRs-TeSt: " + stageId + " -start"
+	endMarkerLine := "X-cRs-TeSt: " + stageId + " -end"
 	logLinesOnly :=
 		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 [Tue Jan 05 02:21:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id "920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
@@ -123,9 +123,9 @@ func (s *readTestSuite) TestReadGetMarkedLinesWithTrailingEmptyLines() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	startMarkerLine := "X-cRs-TeSt: " + stageID + " -start"
-	endMarkerLine := "X-cRs-TeSt: " + stageID + " -end"
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	startMarkerLine := "X-cRs-TeSt: " + stageId + " -start"
+	endMarkerLine := "X-cRs-TeSt: " + stageId + " -end"
 	logLinesOnly :=
 		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 [Tue Jan 05 02:21:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id "920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
@@ -160,9 +160,9 @@ func (s *readTestSuite) TestReadGetMarkedLinesWithPrecedingLines() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	startMarkerLine := "X-cRs-TeSt: " + stageID + " -start"
-	endMarkerLine := "X-cRs-TeSt: " + stageID + " -end"
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	startMarkerLine := "X-cRs-TeSt: " + stageId + " -start"
+	endMarkerLine := "X-cRs-TeSt: " + stageId + " -end"
 	precedingLines :=
 		`[Tue Jan 04 02:21:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id "920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
 	[Tue Jan 04 02:22:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id "920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`
@@ -200,9 +200,9 @@ func (s *readTestSuite) TestFTWLogLines_Contains() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	markerLineStart := "X-cRs-TeSt: " + stageID + "-s"
-	markerLineEnd := "X-cRs-TeSt: " + stageID + "-e"
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLineStart := "X-cRs-TeSt: " + stageId + "-s"
+	markerLineEnd := "X-cRs-TeSt: " + stageId + "-e"
 	logLines :=
 		markerLineStart +
 			`
@@ -275,23 +275,18 @@ func (s *readTestSuite) TestFTWLogLines_ContainsIn404() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLineStart := fmt.Sprint(`[2022-11-12 23:08:18.012572] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
-		"X-cRs-TeSt ", stageID+"-s",
+		"X-cRs-TeSt ", stageId+"-s",
 		`"] [hostname "localhost"] [uri "/status/200"] [unique_id "Y3AZUo3Gja4gB-tPE9uasgAAAA4"]`)
 	markerLineEnd := fmt.Sprint(`[2022-11-12 23:08:18.012580] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
-		"X-cRs-TeSt ", stageID+"-e",
+		"X-cRs-TeSt ", stageId+"-e",
 		`"] [hostname "localhost"] [uri "/status/200"] [unique_id "Y3AZUo3Gja4gB-tPE9uasgBBBB4"]`)
 	logLines := fmt.Sprint("\n", markerLineStart,
 		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`,
 		`[2022-11-12 23:08:18.013007] [core:info] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 AH00128: File does not exist: /apache/htdocs/status/200`,
-<<<<<<< HEAD
-		"\n", markerLine)
-	filename, err := utils.CreateTempFileWithContent("", logLines, "test-errorlog-")
-=======
 		"\n", markerLineEnd)
-	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
->>>>>>> 5b3386a (start and end marker)
+	filename, err := utils.CreateTempFileWithContent("", logLines, "test-errorlog-")
 	s.Require().NoError(err)
 
 	cfg.LogFile = filename
@@ -347,9 +342,9 @@ func (s *readTestSuite) TestFTWLogLines_CheckForLogMarkerIn404() {
 	cfg, err := config.NewConfigFromEnv()
 	s.Require().NoError(err)
 	s.NotNil(cfg)
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
 	markerLine := fmt.Sprint(`[2022-11-12 23:08:18.012572] [-:error] 127.0.0.1:36126 Y3AZUo3Gja4gB-tPE9uasgAAAA4 [client 127.0.0.1] ModSecurity: Warning. Unconditional match in SecAction. [file "/apache/conf/httpd.conf_pod_2022-11-12_22:23"] [line "265"] [id "999999"] [msg "`,
-		"X-cRs-TeSt ", stageID,
+		"X-cRs-TeSt ", stageId,
 		`"] [hostname "localhost"] [uri "/status/200"] [unique_id "Y3AZUo3Gja4gB-tPE9uasgAAAA4"]`)
 	logLines := fmt.Sprint("\n", markerLine,
 		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`,
@@ -368,7 +363,7 @@ func (s *readTestSuite) TestFTWLogLines_CheckForLogMarkerIn404() {
 	}
 	ll.WithStartMarker([]byte(markerLine))
 	ll.WithEndMarker([]byte(markerLine))
-	foundMarker := ll.CheckLogForMarker(stageID, 100)
+	foundMarker := ll.CheckLogForMarker(stageId, 100)
 	s.Equal(strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))
 }
 
@@ -377,26 +372,17 @@ func (s *readTestSuite) TestFindAllIdsInLogs() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-<<<<<<< HEAD
-	markerLine := "X-cRs-TeSt: " + stageID
-	logLines := fmt.Sprint("\n", markerLine, "\n",
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLineStart := "X-cRs-TeSt: " + stageId + "-s"
+	markerLineEnd := "X-cRs-TeSt: " + stageId + "-e"
+	logLines := fmt.Sprint("\n", markerLineStart, "\n",
 		`other stuff [id "1"] something else [id "2"]`, "\n",
 		`other stuff {"blah": "bort,"id": 3}, something else {"id":5},`, "\n",
 		`other stuff {"id": 6}, something else ["id":7],`, "\n",
 		`other stuff something else [id \"8\"]`, "\n",
-		"\n", markerLine)
-	filename, err := utils.CreateTempFileWithContent("", logLines, "test-errorlog-")
-=======
-	markerLineStart := "X-cRs-TeSt: " + stageID + "-s"
-	markerLineEnd := "X-cRs-TeSt: " + stageID + "-e"
-	logLines := fmt.Sprint("\n", markerLineStart,
-		`[id "1"] something else [id "2"]`,
-		`"id": 3, something else {"id":4},`,
-		`something else [id \"5\"]`+"\n",
 		"\n", markerLineEnd)
-	filename, err := utils.CreateTempFileWithContent(logLines, "test-errorlog-")
->>>>>>> 5b3386a (start and end marker)
+	filename, err := utils.CreateTempFileWithContent("", logLines, "test-errorlog-")
+
 	s.Require().NoError(err)
 	cfg.LogFile = filename
 	log, err := os.Open(filename)
@@ -424,8 +410,8 @@ func (s *readTestSuite) TestFalsePositiveIds() {
 	s.Require().NoError(err)
 	s.NotNil(cfg)
 
-	stageID := "dead-beaf-deadbeef-deadbeef-dead"
-	markerLine := "X-cRs-TeSt: " + stageID
+	stageId := "dead-beaf-deadbeef-deadbeef-dead"
+	markerLine := "X-cRs-TeSt: " + stageId
 	logLines := fmt.Sprint("\n", markerLine,
 		`2025/01/02 12:19:00 [info] 117#117: *16117 ModSecurity: Warning. Matched "Operator `,
 		"`Rx' + with parameter `%u[4e00-9fa5]{3,}' against variable `TX:matched' (Value: `",

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -50,7 +50,7 @@ func (s *readTestSuite) TestReadCheckLogForMarkerNoMarkerAtEnd() {
 	ll, err := NewFTWLogLines(cfg)
 	s.Require().NoError(err)
 	ll.WithStartMarker([]byte(markerLine))
-	marker := ll.CheckLogForMarker(stageID, 100)
+	marker := ll.CheckLogForMarker(stageID, 100, []byte(markerLine))
 	s.Equal(string(marker), strings.ToLower(markerLine), "unexpectedly found marker")
 }
 
@@ -75,7 +75,7 @@ func (s *readTestSuite) TestReadCheckLogForMarkerWithMarkerAtEnd() {
 	ll.WithStartMarker([]byte(markerLine))
 	s.Require().NoError(err)
 
-	marker := ll.CheckLogForMarker(stageID, 100)
+	marker := ll.CheckLogForMarker(stageID, 100, []byte(markerLine))
 	s.NotNil(marker, "no marker found")
 
 	s.Equal(marker, bytes.ToLower([]byte(markerLine)), "found unexpected marker")
@@ -358,7 +358,7 @@ func (s *readTestSuite) TestFTWLogLines_CheckForLogMarkerIn404() {
 	}
 	ll.WithStartMarker([]byte(markerLine))
 	ll.WithEndMarker([]byte(markerLine))
-	foundMarker := ll.CheckLogForMarker(stageID, 100)
+	foundMarker := ll.CheckLogForMarker(stageID, 100, nil)
 	s.Equal(strings.ToLower(markerLine), strings.ToLower(string(foundMarker)))
 }
 


### PR DESCRIPTION
I'm investigating some flakiness and found that the same marker might be retrieved for both the starter and the final one. When this happens, the function responsible for retrieving all the marked lines can not locate the starter marker. As a result, it uses all the logs up to the beginning of the file and processes IDs from lines belonging to previous tests, leading to incorrect results. 
My idea is that it can happen when go-ftw is too fast and reads again the same line before the engine/connector manages to write/flush the new logs (which include the final marker) into the file.

From a visual perspective (_Note: The read is performed backward._):



**] Expected scenario:**
start marker: `8888-8888`
final marker: `9999-9999`
```
...
log id:10
8888-8888
log id:11
9999-9999
```
1) We look for the final marker
2) Se start collecting log lines
3) We stop when reaching the start marker
4) log id:10 line is not collected, being out of the markers.


**] Assuming the case that both the start marker and final marker have the same value (equal to the start marker):**
start marker: `8888-8888`
final marker: `8888-8888`
```
...
log id:10
8888-8888
log id:11
9999-9999
```
1) We look for the final marker, in that case, the line `8888-8888` matches
2) From there we start collecting logs
3) `log id:11` is not collected, but rather `log id:10` and all the previous ones are collected.

The PR proposes to:
1) Add a debug log when the start marker is not found and unbounded logs (up to the beginning of the file) are used
2) Introduce a retry mechanism that, when looking for the final marker, repeats the seeking of the log file if the final marker found is equal to the start maker.
3) Do not introduce changes so far if the final marker is found equal to the start marker after some attempts, but print a verbose Warn log line.

It would allow us to have more visibility on the issue and bring in some more resiliency. Anyways I think that it is not expected to have the same start and final marker line, therefore I think adding a check would be beneficial.

I will follow with a test/reproducer whenever I manage to reproduce it in an easy and consistent way