### PR TITLE
fix: use legacy `[no_]log_contains` if set

### DIFF
--- a/test/types.go
+++ b/test/types.go
@@ -165,11 +165,15 @@ func postLoadTest(ruleId uint, testId uint, test *schema.Test) {
 
 func postLoadStage(stage *schema.Stage) {
 	postLoadInput((*Input)(&stage.Input))
+	postLoadOutput((*Output)(&stage.Output))
 }
 
 func postLoadInput(input *Input) {
 	//nolint:staticcheck
 	postProcessAutocompleteHeaders(input.AutocompleteHeaders, input.StopMagic, input)
+}
+func postLoadOutput(output *Output) {
+	postProcessLogContains(output)
 }
 
 func postProcessAutocompleteHeaders(autocompleteHeaders *bool, stopMagic *bool, input *Input) {
@@ -188,4 +192,18 @@ func postProcessAutocompleteHeaders(autocompleteHeaders *bool, stopMagic *bool, 
 	// StopMagic has the inverse boolean logic
 	//nolint:staticcheck
 	input.StopMagic = func() *bool { b := !finalValue; return &b }()
+}
+
+func postProcessLogContains(output *Output) {
+	log := &output.Log
+	//nolint:staticcheck
+	if output.LogContains != "" && log.ExpectIds == nil && log.MatchRegex == "" {
+		//nolint:staticcheck
+		log.MatchRegex = output.LogContains
+	}
+	//nolint:staticcheck
+	if output.NoLogContains != "" && log.NoExpectIds == nil && log.NoMatchRegex == "" {
+		//nolint:staticcheck
+		log.NoMatchRegex = output.NoLogContains
+	}
 }

--- a/test/types_test.go
+++ b/test/types_test.go
@@ -161,6 +161,122 @@ tests:
           status: 200
 `
 
+var logContainsSetsMatchRegex = `---
+meta:
+  author: "tester"
+  description: "Example Test"
+rule_id: 123456
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: "localhost"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Accept: "*/*"
+            Host: "localhost"
+        output:
+          log_contains: homer
+`
+
+var logContainsDoesNotOverrideMatchRegex = `---
+meta:
+  author: "tester"
+  description: "Example Test"
+rule_id: 123456
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: "localhost"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Accept: "*/*"
+            Host: "localhost"
+        output:
+          log_contains: homer
+          log:
+            match_regex: marge
+`
+
+var logContainsDoesNotOverrideExpectId = `---
+meta:
+  author: "tester"
+  description: "Example Test"
+rule_id: 123456
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: "localhost"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Accept: "*/*"
+            Host: "localhost"
+        output:
+          log_contains: homer
+          log:
+            expect_ids: [123456]
+`
+
+var noLogContainsSetsNoMatchRegex = `---
+meta:
+  author: "tester"
+  description: "Example Test"
+rule_id: 123456
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: "localhost"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Accept: "*/*"
+            Host: "localhost"
+        output:
+          no_log_contains: homer
+`
+
+var noLogContainsDoesNotOverrideNoMatchRegex = `---
+meta:
+  author: "tester"
+  description: "Example Test"
+rule_id: 123456
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: "localhost"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Accept: "*/*"
+            Host: "localhost"
+        output:
+          no_log_contains: homer
+          log:
+            no_match_regex: marge
+`
+
+var noLogContainsDoesNotOverrideNoExpectId = `---
+meta:
+  author: "tester"
+  description: "Example Test"
+rule_id: 123456
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: "localhost"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Accept: "*/*"
+            Host: "localhost"
+        output:
+          no_log_contains: homer
+          log:
+            no_expect_ids: [123456]
+`
+
 func (s *typesTestSuite) TestAutocompleteHeadersDefault_StopMagicDefault() {
 	test, err := GetTestFromYaml([]byte(autocompleteHeadersDefaultYaml), "")
 	s.NoError(err, "Parsing YAML shouldn't fail")
@@ -248,4 +364,52 @@ func (s *typesTestSuite) TestAutocompleteHeadersTrue_StopMagicFalse() {
 	s.True(*input.AutocompleteHeaders)
 	//nolint:staticcheck
 	s.False(*input.StopMagic)
+}
+
+func (s *typesTestSuite) TestLogContainsSetsMatchRegex() {
+	test, err := GetTestFromYaml([]byte(logContainsSetsMatchRegex), "")
+	s.NoError(err, "Parsing YAML shouldn't fail")
+
+	output := test.Tests[0].Stages[0].Output
+	s.Equal("homer", output.Log.MatchRegex)
+}
+
+func (s *typesTestSuite) TestLogContainsDoesNotOverrideMatchRegex() {
+	test, err := GetTestFromYaml([]byte(logContainsDoesNotOverrideMatchRegex), "")
+	s.NoError(err, "Parsing YAML shouldn't fail")
+
+	output := test.Tests[0].Stages[0].Output
+	s.Equal("marge", output.Log.MatchRegex)
+}
+
+func (s *typesTestSuite) TestLogContainsDoesNotOverrideExpectIds() {
+	test, err := GetTestFromYaml([]byte(logContainsDoesNotOverrideExpectId), "")
+	s.NoError(err, "Parsing YAML shouldn't fail")
+
+	output := test.Tests[0].Stages[0].Output
+	s.Equal("", output.Log.MatchRegex)
+}
+
+func (s *typesTestSuite) TestNoLogContainsSetsNoMatchRegex() {
+	test, err := GetTestFromYaml([]byte(noLogContainsSetsNoMatchRegex), "")
+	s.NoError(err, "Parsing YAML shouldn't fail")
+
+	output := test.Tests[0].Stages[0].Output
+	s.Equal("homer", output.Log.NoMatchRegex)
+}
+
+func (s *typesTestSuite) TestNoLogContainsDoesNotOverrideNoMatchRegex() {
+	test, err := GetTestFromYaml([]byte(noLogContainsDoesNotOverrideNoMatchRegex), "")
+	s.NoError(err, "Parsing YAML shouldn't fail")
+
+	output := test.Tests[0].Stages[0].Output
+	s.Equal("marge", output.Log.NoMatchRegex)
+}
+
+func (s *typesTestSuite) TestNoLogContainsDoesNotOverrideNoExpectIds() {
+	test, err := GetTestFromYaml([]byte(noLogContainsDoesNotOverrideNoExpectId), "")
+	s.NoError(err, "Parsing YAML shouldn't fail")
+
+	output := test.Tests[0].Stages[0].Output
+	s.Equal("", output.Log.NoMatchRegex)
 }


### PR DESCRIPTION
`[no_]log_contains` was deprecated but not removed. During the refactoring to `[no_]expect_ids` / `[no_]match_regex` using the old values was accidentally dropped.

Refs #428