### PR TITLE
feat: implement `encoded_data`

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -409,7 +409,7 @@ func getRequestFromTest(testInput test.Input) *ftwhttp.Request {
 		Version: testInput.GetVersion(),
 	}
 
-	data := testInput.ParseData()
+	data := testInput.GetData()
 	// create a new request
 	req = ftwhttp.NewRequest(rline, testInput.Headers,
 		data, *testInput.AutocompleteHeaders)

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -601,4 +602,40 @@ func (s *runTestSuite) TestVirtualHostMode_True() {
 	request := buildMarkerRequest(context, input, uuid.NewString())
 
 	s.Equal("not-localhost_virtual-host", request.Headers().Get("Host"))
+}
+
+func (s *runTestSuite) TestGetRequestFromData() {
+	data := "This is Springfield"
+	boolean := true
+	method := "POST"
+	input := test.Input{
+		AutocompleteHeaders: &boolean,
+		Method:              &method,
+		Headers:             ftwhttp.Header{},
+		DestAddr:            &s.dest.DestAddr,
+		Port:                &s.dest.Port,
+		Protocol:            &s.dest.Protocol,
+		Data:                &data,
+	}
+	request := getRequestFromTest(input)
+
+	s.Equal(data, string(request.Data()))
+}
+
+func (s *runTestSuite) TestGetRequestFromEncodedData() {
+	data := base64.StdEncoding.EncodeToString([]byte("This is Springfield"))
+	boolean := true
+	method := "POST"
+	input := test.Input{
+		AutocompleteHeaders: &boolean,
+		Method:              &method,
+		Headers:             ftwhttp.Header{},
+		DestAddr:            &s.dest.DestAddr,
+		Port:                &s.dest.Port,
+		Protocol:            &s.dest.Protocol,
+		Data:                &data,
+	}
+	request := getRequestFromTest(input)
+
+	s.Equal(data, string(request.Data()))
 }

--- a/test/data.go
+++ b/test/data.go
@@ -5,27 +5,49 @@ package test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
 	"github.com/rs/zerolog/log"
 )
 
-// ParseData returns the data from the test. Will parse and interpret Go text/template inside it.
-func (i *Input) ParseData() []byte {
+// GetData returns the body data for the request, whether specified via `data` or `encoded_data`.
+// If `data` contains Go templates, these will be evaluated.
+func (i *Input) GetData() []byte {
+	if i.Data != nil {
+		return i.parseData()
+	}
+	if i.EncodedData != nil {
+		decoded, err := base64.StdEncoding.DecodeString(*i.EncodedData)
+		if err != nil {
+			log.Debug().Msgf("test/data: error decoding data fro Base64: %s", err.Error())
+			return nil
+		}
+		return decoded
+	}
+
+	return nil
+}
+
+func (i *Input) parseData() []byte {
+	if i.Data == nil {
+		return nil
+	}
+
 	var err error
 	var tpl bytes.Buffer
 
 	// Parse data for Go template
-	if i.Data != nil {
-		t := template.New("ftw").Funcs(sprig.TxtFuncMap())
-		t, err = t.Parse(*i.Data)
-		if err != nil {
-			log.Debug().Msgf("test/data: error parsing template in data: %s", err.Error())
-		}
-		if err = t.Execute(&tpl, nil); err != nil {
-			log.Debug().Msgf("test/data: error executing template: %s", err.Error())
-		}
+	t := template.New("ftw").Funcs(sprig.TxtFuncMap())
+	t, err = t.Parse(*i.Data)
+	if err != nil {
+		log.Debug().Msgf("test/data: error parsing template in data: %s", err.Error())
+		return nil
+	}
+	if err = t.Execute(&tpl, nil); err != nil {
+		log.Debug().Msgf("test/data: error executing template: %s", err.Error())
+		return nil
 	}
 
 	return tpl.Bytes()


### PR DESCRIPTION
`encoded_data` has been part of the spec for a while but never implemented. Allows passing body data base64 encoded for complex bodies.

Refs #428