### PR TITLE
fix: output ftw result error

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -244,7 +244,7 @@ func buildOutput(cmd *cobra.Command) (*output.Output, error) {
 	if outputFilename == "" {
 		outputFile = os.Stdout
 	} else {
-		outputFile, err = os.Open(outputFilename)
+		outputFile, err = os.Create(outputFilename)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION

```
 --output json --file r.json
```

output test result eroor with 
```
Error: open r.json: no such file or directory
```
change Open to  Create