### PR TITLE
fix: tolerate tests that do not specify any headers

### DIFF
--- a/ftwhttp/header.go
+++ b/ftwhttp/header.go
@@ -111,11 +111,8 @@ func (h Header) WriteBytes(b *bytes.Buffer) (int, error) {
 	return count, nil
 }
 
-// Clone returns a copy of h or nil if h is nil.
+// Clone returns a copy of h
 func (h Header) Clone() Header {
-	if h == nil {
-		return nil
-	}
 	clone := make(Header)
 
 	for n, v := range h {

--- a/ftwhttp/request_test.go
+++ b/ftwhttp/request_test.go
@@ -289,3 +289,17 @@ func (s *requestTestSuite) TestRequestEncodesPostData() {
 		})
 	}
 }
+
+func (s *requestTestSuite) TestNewRequest_EmptyHeaders() {
+	rl := &RequestLine{
+		Method:  "POST",
+		URI:     "/path",
+		Version: "1.1",
+	}
+
+	req := NewRequest(rl, nil, []byte{}, false)
+
+	headers := req.Headers()
+	s.NotNil(headers)
+	s.Empty(headers)
+}


### PR DESCRIPTION
Fixes #437