### PR TITLE
chore: expose GitHub token for API requests from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           go-version: ^1.23
           cache: true
+        env:
+          # self-updater tests make requests to the GitHub API
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Go Tests
         run: go test -coverprofile coverage.out ./...


### PR DESCRIPTION
The self-updater tests make API requests to GitHub and can run into a rate limit if they are not authenticated.