### PR TITLE
feat: implement skipping TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Flags:
   -r, --rate-limit duration                    Limit the request rate to the server to 1 request per specified duration. 0 is the default, and disables rate limiting.
       --read-timeout duration                  timeout for receiving responses during test execution (default 10s)
       --show-failures-only                     shows only the results of failed tests
+      -skip-tls-verification                   Skips TLS certificate checks. Useful for testing domains with self-signed TLS ceritificates.
   -t, --time                                   show time spent per test
       --wait-delay duration                    Time to wait between retries for all wait operations. (default 1s)
       --wait-for-connection-timeout duration   Http connection timeout, The timeout includes connection time, any redirects, and reading the response body. (default 3s)
@@ -144,7 +145,6 @@ Flags:
       --wait-for-expect-header string          Expect response header pattern.
       --wait-for-expect-status-code int        Expect response code e.g. 200, 204, ... .
       --wait-for-host string                   Wait for host to be available before running tests.
-      --wait-for-insecure-skip-tls-verify      Skips tls certificate checks for the HTTPS request.
       --wait-for-no-redirect                   Do not follow HTTP 3xx redirects.
       --wait-for-timeout duration              Sets the timeout for all wait operations, 0 is unlimited. (default 10s)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -24,34 +24,34 @@ import (
 )
 
 const (
-	connectTimeoutFlag               = "connect-timeout"
-	dirFlag                          = "dir"
-	globFlag                         = "glob"
-	excludeFlag                      = "exclude"
-	failFastFlag                     = "fail-fast"
-	fileFlag                         = "file"
-	includeFlag                      = "include"
-	includeTagsFlag                  = "include-tags"
-	logFileFlag                      = "log-file"
-	maxMarkerRetriesFlag             = "max-marker-retries"
-	maxMarkerLogLinesFlag            = "max-marker-log-lines"
-	outputFlag                       = "output"
-	readTimeoutFlag                  = "read-timeout"
-	rateLimitFlag                    = "rate-limit"
-	showFailuresOnlyFlag             = "show-failures-only"
-	timeFlag                         = "time"
-	waitDelayFlag                    = "wait-delay"
-	waitForConnectionTimeoutFlag     = "wait-for-connection-timeout"
-	waitForExpectBodyJsonFlag        = "wait-for-expect-body-json"
-	waitForExpectBodyRegexFlag       = "wait-for-expect-body-regex"
-	waitForExpectBodyXpathFlag       = "wait-for-expect-body-xpath"
-	waitForExpectHeaderFlag          = "wait-for-expect-header"
-	waitForExpectStatusCodeFlag      = "wait-for-expect-status-code"
-	waitForHostFlag                  = "wait-for-host"
-	waitForInsecureSkipTlsVerifyFlag = "wait-for-insecure-skip-tls-verify"
-	waitForNoRedirectFlag            = "wait-for-no-redirect"
-	waitForTimeoutFlag               = "wait-for-timeout"
-	reportTriggeredRulesFlag         = "report-triggered-rules"
+	connectTimeoutFlag           = "connect-timeout"
+	dirFlag                      = "dir"
+	globFlag                     = "glob"
+	excludeFlag                  = "exclude"
+	failFastFlag                 = "fail-fast"
+	fileFlag                     = "file"
+	includeFlag                  = "include"
+	includeTagsFlag              = "include-tags"
+	logFileFlag                  = "log-file"
+	maxMarkerRetriesFlag         = "max-marker-retries"
+	maxMarkerLogLinesFlag        = "max-marker-log-lines"
+	outputFlag                   = "output"
+	readTimeoutFlag              = "read-timeout"
+	rateLimitFlag                = "rate-limit"
+	showFailuresOnlyFlag         = "show-failures-only"
+	skipTlsVerificationFlag      = "skip-tls-verification"
+	timeFlag                     = "time"
+	waitDelayFlag                = "wait-delay"
+	waitForConnectionTimeoutFlag = "wait-for-connection-timeout"
+	waitForExpectBodyJsonFlag    = "wait-for-expect-body-json"
+	waitForExpectBodyRegexFlag   = "wait-for-expect-body-regex"
+	waitForExpectBodyXpathFlag   = "wait-for-expect-body-xpath"
+	waitForExpectHeaderFlag      = "wait-for-expect-header"
+	waitForExpectStatusCodeFlag  = "wait-for-expect-status-code"
+	waitForHostFlag              = "wait-for-host"
+	waitForNoRedirectFlag        = "wait-for-no-redirect"
+	waitForTimeoutFlag           = "wait-for-timeout"
+	reportTriggeredRulesFlag     = "report-triggered-rules"
 )
 
 // NewRunCmd represents the run command
@@ -75,8 +75,9 @@ func NewRunCommand() *cobra.Command {
 	runCmd.Flags().BoolP(showFailuresOnlyFlag, "", false, "shows only the results of failed tests")
 	runCmd.Flags().Duration(connectTimeoutFlag, 3*time.Second, "timeout for connecting to endpoints during test execution")
 	runCmd.Flags().Duration(readTimeoutFlag, 10*time.Second, "timeout for receiving responses during test execution")
-	runCmd.Flags().Int(maxMarkerRetriesFlag, 20, "maximum number of times the search for log markers will be repeated.\nEach time an additional request is sent to the web server, eventually forcing the log to be flushed")
-	runCmd.Flags().Int(maxMarkerLogLinesFlag, 500, "maximum number of lines to search for a marker before aborting")
+	runCmd.Flags().Uint(maxMarkerRetriesFlag, 20, "maximum number of times the search for log markers will be repeated.\nEach time an additional request is sent to the web server, eventually forcing the log to be flushed")
+	runCmd.Flags().Uint(maxMarkerLogLinesFlag, 500, "maximum number of lines to search for a marker before aborting")
+	runCmd.Flags().Bool(skipTlsVerificationFlag, http.DefaultInsecureSkipTLSVerify, "Skips TLS certificate checks. Useful for testing domains with self-signed TLS ceritificates.")
 	runCmd.Flags().String(waitForHostFlag, "", "Wait for host to be available before running tests.")
 	runCmd.Flags().Duration(waitDelayFlag, 1*time.Second, "Time to wait between retries for all wait operations.")
 	runCmd.Flags().Duration(waitForTimeoutFlag, 10*time.Second, "Sets the timeout for all wait operations, 0 is unlimited.")
@@ -86,7 +87,6 @@ func NewRunCommand() *cobra.Command {
 	runCmd.Flags().String(waitForExpectBodyXpathFlag, "", "Expect response body XPath pattern.")
 	runCmd.Flags().String(waitForExpectHeaderFlag, "", "Expect response header pattern.")
 	runCmd.Flags().Duration(waitForConnectionTimeoutFlag, http.DefaultConnectionTimeout, "Http connection timeout, The timeout includes connection time, any redirects, and reading the response body.")
-	runCmd.Flags().Bool(waitForInsecureSkipTlsVerifyFlag, http.DefaultInsecureSkipTLSVerify, "Skips tls certificate checks for the HTTPS request.")
 	runCmd.Flags().Bool(waitForNoRedirectFlag, http.DefaultNoRedirect, "Do not follow HTTP 3xx redirects.")
 	runCmd.Flags().DurationP(rateLimitFlag, "r", 0, "Limit the request rate to the server to 1 request per specified duration. 0 is the default, and disables rate limiting.")
 	runCmd.Flags().Bool(failFastFlag, false, "Fail on first failed test")
@@ -127,22 +127,67 @@ func runE(cmd *cobra.Command, _ []string) error {
 
 //gocyclo:ignore
 func buildRunnerConfig(cmd *cobra.Command) (*config.RunnerConfig, error) {
-	exclude, _ := cmd.Flags().GetString(excludeFlag)
-	include, _ := cmd.Flags().GetString(includeFlag)
-	includeTags, _ := cmd.Flags().GetString(includeTagsFlag)
-	logFilePath, _ := cmd.Flags().GetString(logFileFlag)
+	exclude, err := cmd.Flags().GetString(excludeFlag)
+	if err != nil {
+		return nil, err
+	}
+	include, err := cmd.Flags().GetString(includeFlag)
+	if err != nil {
+		return nil, err
+	}
+	includeTags, err := cmd.Flags().GetString(includeTagsFlag)
+	if err != nil {
+		return nil, err
+	}
+	logFilePath, err := cmd.Flags().GetString(logFileFlag)
+	if err != nil {
+		return nil, err
+	}
+	skipTlsVerification, err := cmd.Flags().GetBool(skipTlsVerificationFlag)
+	if err != nil {
+		return nil, err
+	}
 	// wait4x flags
-	waitForHost, _ := cmd.Flags().GetString(waitForHostFlag)
-	timeout, _ := cmd.Flags().GetDuration(waitForTimeoutFlag)
-	interval, _ := cmd.Flags().GetDuration(waitDelayFlag)
-	expectStatusCode, _ := cmd.Flags().GetInt(waitForExpectStatusCodeFlag)
-	expectBodyRegex, _ := cmd.Flags().GetString(waitForExpectBodyRegexFlag)
-	expectBodyJSON, _ := cmd.Flags().GetString(waitForExpectBodyJsonFlag)
-	expectBodyXPath, _ := cmd.Flags().GetString(waitForExpectBodyXpathFlag)
-	expectHeader, _ := cmd.Flags().GetString(waitForExpectHeaderFlag)
-	connectionTimeout, _ := cmd.Flags().GetDuration(waitForConnectionTimeoutFlag)
-	insecureSkipTLSVerify, _ := cmd.Flags().GetBool(waitForInsecureSkipTlsVerifyFlag)
-	noRedirect, _ := cmd.Flags().GetBool(waitForNoRedirectFlag)
+	waitForHost, err := cmd.Flags().GetString(waitForHostFlag)
+	if err != nil {
+		return nil, err
+	}
+	timeout, err := cmd.Flags().GetDuration(waitForTimeoutFlag)
+	if err != nil {
+		return nil, err
+	}
+	interval, err := cmd.Flags().GetDuration(waitDelayFlag)
+	if err != nil {
+		return nil, err
+	}
+	expectStatusCode, err := cmd.Flags().GetInt(waitForExpectStatusCodeFlag)
+	if err != nil {
+		return nil, err
+	}
+	expectBodyRegex, err := cmd.Flags().GetString(waitForExpectBodyRegexFlag)
+	if err != nil {
+		return nil, err
+	}
+	expectBodyJSON, err := cmd.Flags().GetString(waitForExpectBodyJsonFlag)
+	if err != nil {
+		return nil, err
+	}
+	expectBodyXPath, err := cmd.Flags().GetString(waitForExpectBodyXpathFlag)
+	if err != nil {
+		return nil, err
+	}
+	expectHeader, err := cmd.Flags().GetString(waitForExpectHeaderFlag)
+	if err != nil {
+		return nil, err
+	}
+	connectionTimeout, err := cmd.Flags().GetDuration(waitForConnectionTimeoutFlag)
+	if err != nil {
+		return nil, err
+	}
+	noRedirect, err := cmd.Flags().GetBool(waitForNoRedirectFlag)
+	if err != nil {
+		return nil, err
+	}
 
 	if exclude != "" && include != "" {
 		cmd.SilenceUsage = false
@@ -150,14 +195,39 @@ func buildRunnerConfig(cmd *cobra.Command) (*config.RunnerConfig, error) {
 	}
 
 	runnerConfig := config.NewRunnerConfiguration(cfg)
-	runnerConfig.ShowTime, _ = cmd.Flags().GetBool(timeFlag)
-	runnerConfig.ShowOnlyFailed, _ = cmd.Flags().GetBool(showFailuresOnlyFlag)
-	runnerConfig.ConnectTimeout, _ = cmd.Flags().GetDuration(connectTimeoutFlag)
-	runnerConfig.ReadTimeout, _ = cmd.Flags().GetDuration(readTimeoutFlag)
-	runnerConfig.MaxMarkerRetries, _ = cmd.Flags().GetUint(maxMarkerRetriesFlag)
-	runnerConfig.MaxMarkerLogLines, _ = cmd.Flags().GetUint(maxMarkerLogLinesFlag)
-	runnerConfig.RateLimit, _ = cmd.Flags().GetDuration(rateLimitFlag)
-	runnerConfig.FailFast, _ = cmd.Flags().GetBool(failFastFlag)
+	runnerConfig.ShowTime, err = cmd.Flags().GetBool(timeFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.ShowOnlyFailed, err = cmd.Flags().GetBool(showFailuresOnlyFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.ConnectTimeout, err = cmd.Flags().GetDuration(connectTimeoutFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.ReadTimeout, err = cmd.Flags().GetDuration(readTimeoutFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.MaxMarkerRetries, err = cmd.Flags().GetUint(maxMarkerRetriesFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.MaxMarkerLogLines, err = cmd.Flags().GetUint(maxMarkerLogLinesFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.RateLimit, err = cmd.Flags().GetDuration(rateLimitFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.FailFast, err = cmd.Flags().GetBool(failFastFlag)
+	if err != nil {
+		return nil, err
+	}
+	runnerConfig.SkipTlsVerification = skipTlsVerification
 
 	if cloud {
 		runnerConfig.RunMode = config.CloudRunMode
@@ -166,7 +236,6 @@ func buildRunnerConfig(cmd *cobra.Command) (*config.RunnerConfig, error) {
 		runnerConfig.LogFilePath = logFilePath
 	}
 
-	var err error
 	if include != "" {
 		if runnerConfig.Include, err = regexp.Compile(include); err != nil {
 			return nil, fmt.Errorf("invalid --%s regular expression: %w", includeFlag, err)
@@ -196,7 +265,7 @@ func buildRunnerConfig(cmd *cobra.Command) (*config.RunnerConfig, error) {
 			http.WithExpectBodyXPath(expectBodyXPath),
 			http.WithExpectHeader(expectHeader),
 			http.WithTimeout(connectionTimeout),
-			http.WithInsecureSkipTLSVerify(insecureSkipTLSVerify),
+			http.WithInsecureSkipTLSVerify(skipTlsVerification),
 			http.WithNoRedirect(noRedirect),
 		)
 		checkers := []checker.Checker{hc}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -154,6 +154,7 @@ func (s *runCmdTestSuite) TestFlags() {
 		"--" + readTimeoutFlag, "5s",
 		"--" + maxMarkerRetriesFlag, "6",
 		"--" + maxMarkerLogLinesFlag, "7",
+		"--" + skipTlsVerificationFlag,
 		"--" + waitForHostFlag, "https://some-host.com",
 		"--" + waitDelayFlag, "9s",
 		"--" + waitForTimeoutFlag, "10s",
@@ -163,7 +164,6 @@ func (s *runCmdTestSuite) TestFlags() {
 		"--" + waitForExpectBodyXpathFlag, "count(//p)",
 		"--" + waitForExpectHeaderFlag, "X-Some-Header",
 		"--" + waitForConnectionTimeoutFlag, "11s",
-		"--" + waitForInsecureSkipTlsVerifyFlag,
 		"--" + waitForNoRedirectFlag,
 		"--" + rateLimitFlag, "12s",
 		"--" + failFastFlag,
@@ -194,9 +194,11 @@ func (s *runCmdTestSuite) TestFlags() {
 	s.NoError(err)
 	readTimeout, err := cmd.Flags().GetDuration(readTimeoutFlag)
 	s.NoError(err)
-	maxMarkerRetries, err := cmd.Flags().GetInt(maxMarkerRetriesFlag)
+	maxMarkerRetries, err := cmd.Flags().GetUint(maxMarkerRetriesFlag)
 	s.NoError(err)
-	maxMarkerLogLines, err := cmd.Flags().GetInt(maxMarkerLogLinesFlag)
+	maxMarkerLogLines, err := cmd.Flags().GetUint(maxMarkerLogLinesFlag)
+	s.NoError(err)
+	waitForInsecureSkipTlsVerify, err := cmd.Flags().GetBool(skipTlsVerificationFlag)
 	s.NoError(err)
 	waitForHost, err := cmd.Flags().GetString(waitForHostFlag)
 	s.NoError(err)
@@ -215,8 +217,6 @@ func (s *runCmdTestSuite) TestFlags() {
 	waitForExpectHeader, err := cmd.Flags().GetString(waitForExpectHeaderFlag)
 	s.NoError(err)
 	waitForConnectionTimeout, err := cmd.Flags().GetDuration(waitForConnectionTimeoutFlag)
-	s.NoError(err)
-	waitForInsecureSkipTlsVerify, err := cmd.Flags().GetBool(waitForInsecureSkipTlsVerifyFlag)
 	s.NoError(err)
 	waitForNoRedirect, err := cmd.Flags().GetBool(waitForNoRedirectFlag)
 	s.NoError(err)
@@ -237,8 +237,8 @@ func (s *runCmdTestSuite) TestFlags() {
 	s.Equal(true, showFailuresOnly)
 	s.Equal(4*time.Second, connectTimeout)
 	s.Equal(5*time.Second, readTimeout)
-	s.Equal(6, maxMarkerRetries)
-	s.Equal(7, maxMarkerLogLines)
+	s.Equal(uint(6), maxMarkerRetries)
+	s.Equal(uint(7), maxMarkerLogLines)
 	s.Equal("https://some-host.com", waitForHost)
 	s.Equal(9*time.Second, waitDelay)
 	s.Equal(10*time.Second, waitForTimeout)

--- a/config/config.go
+++ b/config/config.go
@@ -16,14 +16,13 @@ import (
 
 // NewDefaultConfig initializes the configuration with default values
 func NewDefaultConfig() *FTWConfiguration {
-	cfg := &FTWConfiguration{
+	return &FTWConfiguration{
 		LogFile:             "",
 		LogMarkerHeaderName: DefaultLogMarkerHeaderName,
 		RunMode:             DefaultRunMode,
 		MaxMarkerRetries:    DefaultMaxMarkerRetries,
 		MaxMarkerLogLines:   DefaultMaxMarkerLogLines,
 	}
-	return cfg
 }
 
 // NewCloudConfig initializes the configuration with cloud values

--- a/config/runner_config.go
+++ b/config/runner_config.go
@@ -43,6 +43,9 @@ type RunnerConfig struct {
 	TestOverride        FTWTestOverride
 	MaxMarkerRetries    uint
 	MaxMarkerLogLines   uint
+	// SkipTlsVerification skips certificate validation. Useful for connecting
+	// to domains with a self-signed certificate.
+	SkipTlsVerification bool
 }
 
 type PlatformOverrides struct {
@@ -58,6 +61,7 @@ func NewRunnerConfiguration(cfg *FTWConfiguration) *RunnerConfig {
 		MaxMarkerLogLines:   cfg.MaxMarkerLogLines,
 		MaxMarkerRetries:    cfg.MaxMarkerRetries,
 		RunMode:             cfg.RunMode,
+		SkipTlsVerification: cfg.SkipTlsVerification,
 	}
 
 	if cfg.IncludeTests != nil {

--- a/config/types.go
+++ b/config/types.go
@@ -46,6 +46,8 @@ type FTWConfiguration struct {
 	ExcludeTests *FTWRegexp `koanf:"exclude"`
 	// IncludeTags is a regular expression for tests to include, matched aginst the tags of tests (same as --tag)
 	IncludeTags *FTWRegexp `koanf:"include_tags"`
+	// to domains with a self-signed certificate.
+	SkipTlsVerification bool `koanf:"skip_tls_verification"`
 }
 
 // FTWTestOverride holds four lists:

--- a/ftwhttp/client_test.go
+++ b/ftwhttp/client_test.go
@@ -38,7 +38,7 @@ func (s *clientTestSuite) SetupSuite() {
 
 func (s *clientTestSuite) SetupTest() {
 	var err error
-	s.client, err = NewClient(NewClientConfig())
+	s.client, err = NewClientWithConfig(NewClientConfig())
 	s.Require().NoError(err)
 	s.Require().Equal(s.client.config.RateLimiter, rate.NewLimiter(rate.Inf, 1))
 	s.Nil(s.client.Transport, "Transport not expected to be initialized yet")

--- a/ftwhttp/response_test.go
+++ b/ftwhttp/response_test.go
@@ -84,7 +84,7 @@ func (s *responseTestSuite) responseWithCookies(w http.ResponseWriter, r *http.R
 
 func (s *responseTestSuite) SetupTest() {
 	var err error
-	s.client, err = NewClient(NewClientConfig())
+	s.client, err = NewClientWithConfig(NewClientConfig())
 	s.Require().NoError(err)
 }
 

--- a/ftwhttp/types.go
+++ b/ftwhttp/types.go
@@ -22,6 +22,9 @@ type ClientConfig struct {
 	RootCAs *x509.CertPool
 	// RateLimiter is the rate limiter to use for requests.
 	RateLimiter *rate.Limiter
+	// SkipTlsVerification skips certificate validation. Useful for connecting
+	// to domains with a self-signed certificate.
+	SkipTlsVerification bool
 }
 
 // Client is the top level abstraction in http

--- a/runner/check_base.go
+++ b/runner/check_base.go
@@ -118,7 +118,3 @@ func (c *FTWCheck) GetTriggeredRules() []uint {
 	}
 	return c.log.TriggeredRules()
 }
-
-func (c *FTWCheck) Close() error {
-	return c.log.Cleanup()
-}

--- a/runner/check_logs_test.go
+++ b/runner/check_logs_test.go
@@ -66,7 +66,7 @@ func (s *checkLogsTestSuite) SetupTest() {
 }
 
 func (s *checkLogsTestSuite) TearDownTest() {
-	err := s.check.Close()
+	err := s.context.LogLines.Cleanup()
 	s.Require().NoError(err)
 }
 

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -165,6 +165,8 @@ func (s *runTestSuite) writeMarkerOrMessageToTestServerLog(logLines string, r *h
 }
 
 func (s *runTestSuite) TearDownTest() {
+	err := s.context.LogLines.Cleanup()
+	s.NoError(err)
 	s.ts.Close()
 }
 
@@ -384,7 +386,7 @@ func (s *runTestSuite) TestGetRequestFromTestWithAutocompleteHeaders() {
 	request, err := getRequestFromTest(input)
 	s.Require().NoError(err)
 
-	client, err := ftwhttp.NewClient(ftwhttp.NewClientConfig())
+	client, err := ftwhttp.NewClientWithConfig(ftwhttp.NewClientConfig())
 	s.Require().NoError(err)
 
 	dest := &ftwhttp.Destination{
@@ -420,7 +422,7 @@ func (s *runTestSuite) TestGetRequestFromTestWithoutAutocompleteHeaders() {
 	request, err := getRequestFromTest(input)
 	s.Require().NoError(err)
 
-	client, err := ftwhttp.NewClient(ftwhttp.NewClientConfig())
+	client, err := ftwhttp.NewClientWithConfig(ftwhttp.NewClientConfig())
 	s.Require().NoError(err)
 
 	dest := &ftwhttp.Destination{
@@ -651,7 +653,7 @@ func (s *runTestSuite) TestTriggeredRules() {
 }
 
 func (s *runTestSuite) TestEncodedRequest() {
-	client, err := ftwhttp.NewClient(ftwhttp.NewClientConfig())
+	client, err := ftwhttp.NewClientWithConfig(ftwhttp.NewClientConfig())
 	s.Require().NoError(err)
 	ll, err := waflog.NewFTWLogLines(s.runnerConfig)
 	s.Require().NoError(err)
@@ -665,7 +667,6 @@ func (s *runTestSuite) TestEncodedRequest() {
 	}
 	stage := s.ftwTests[0].Tests[0].Stages[0]
 	_check, err := NewCheck(s.context)
-	s.T().Cleanup(func() { _ = _check.Close() })
 	s.Require().NoError(err)
 
 	err = RunStage(s.context, _check, schema.Test{}, stage)
@@ -674,7 +675,7 @@ func (s *runTestSuite) TestEncodedRequest() {
 }
 
 func (s *runTestSuite) TestEncodedRequest_InvalidEncoding() {
-	client, err := ftwhttp.NewClient(ftwhttp.NewClientConfig())
+	client, err := ftwhttp.NewClientWithConfig(ftwhttp.NewClientConfig())
 	s.Require().NoError(err)
 	ll, err := waflog.NewFTWLogLines(s.runnerConfig)
 	s.Require().NoError(err)
@@ -688,7 +689,6 @@ func (s *runTestSuite) TestEncodedRequest_InvalidEncoding() {
 	}
 	stage := s.ftwTests[0].Tests[0].Stages[0]
 	_check, err := NewCheck(s.context)
-	s.T().Cleanup(func() { _ = _check.Close() })
 	s.Require().NoError(err)
 
 	err = RunStage(s.context, _check, schema.Test{}, stage)

--- a/waflog/waflog.go
+++ b/waflog/waflog.go
@@ -44,7 +44,7 @@ func (ll *FTWLogLines) WithEndMarker(marker []byte) {
 
 // Cleanup closes the log file
 func (ll *FTWLogLines) Cleanup() error {
-	if ll.logFile != nil {
+	if ll != nil && ll.logFile != nil {
 		return ll.logFile.Close()
 	}
 	return nil


### PR DESCRIPTION
We had a CLI flag for wait4x to disable TLS verification but no such option for the HTTP client.

This change replaces the specific flag for wait4x with a global flag `skip-tls-verification`, that configures both wait4x and the HTTP client.

Fixes #503