### PR TITLE
docs: update docs on `autocomplete_headers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Tests can be altered using four lists:
   - `ordered_headers`: overrides headers, the format is a list of `name` / `value` pairs
   - `method`: overrides the method used to perform the request
   - `data`: overrides data sent in the request
-  - `autocomplete_headers`: overrides header autocompletion (currently sets `Connection: close` and `Content-Length` for requests with body data)
+  - `autocomplete_headers`: overrides header autocompletion (currently sets `Connection: close` and `Content-Length` and `Content-Type` for requests with body data)
   - `encodedrequest`: overrides base64 encoded request
   - `virtual_host_mode`: set the `Host` header specified in tests for internal requests as well (overrides sending internal requests to `localhost`)
 - `ignore` is for tests you want to ignore. You should add a comment on why you ignore the test


### PR DESCRIPTION
`autocomplete_headers` also adds `Content-Type` header