### PR TITLE
fix: use aliases for major version upgrades of dependencies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/env/v2"
+	koanfenvv2 "github.com/knadh/koanf/providers/env/v2"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
 	koanfv2 "github.com/knadh/koanf/v2"
@@ -72,7 +72,7 @@ func NewConfigFromFile(cfgFile string) (*FTWConfiguration, error) {
 // NewConfigFromEnv reads configuration information from environment variables that start with `FTW_`
 func NewConfigFromEnv() (*FTWConfiguration, error) {
 	k := getKoanfInstance()
-	options := env.Opt{
+	options := koanfenvv2.Opt{
 		Prefix: "FTW_",
 		TransformFunc: func(key string, value string) (string, any) {
 			cleanKey := strings.ReplaceAll(strings.ToLower(
@@ -80,7 +80,7 @@ func NewConfigFromEnv() (*FTWConfiguration, error) {
 			return cleanKey, value
 		},
 	}
-	err := k.Load(env.Provider(".", options), nil)
+	err := k.Load(koanfenvv2.Provider(".", options), nil)
 
 	if err != nil {
 		return nil, err

--- a/test/data_test.go
+++ b/test/data_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/coreruleset/go-ftw/ftwhttp/header_values"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
-	"go.yaml.in/yaml/v4"
+	yamlv4 "go.yaml.in/yaml/v4"
 )
 
 var repeatTestSprig = `foo=%3d++++++++++++++++++++++++++++++++++`
@@ -43,7 +43,7 @@ uri: "/"
 `
 
 	input := &schema.Input{}
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 	s.True(*input.AutocompleteHeaders)
 }
@@ -64,7 +64,7 @@ autocomplete_headers: false
 uri: "/"
 `
 	input := &schema.Input{}
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 	s.Empty(*input.Version)
 	s.False(*input.AutocompleteHeaders)
@@ -87,7 +87,7 @@ uri: "/"
 `
 	input := &schema.Input{}
 	var data []byte
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 
 	internalInput := NewInput(input)
@@ -114,7 +114,7 @@ uri: "/"
 `
 	input := &schema.Input{}
 	var data []byte
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 
 	internalData := NewInput(input)
@@ -141,7 +141,7 @@ uri: "/"
 `
 	input := &schema.Input{}
 	var data []byte
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 
 	internalData := NewInput(input)
@@ -165,7 +165,7 @@ uri: "/"
 `
 	input := &schema.Input{}
 	var data []byte
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 
 	internalData := NewInput(input)
@@ -189,7 +189,7 @@ uri: "/"
 `
 	input := &schema.Input{}
 	var data []byte
-	err := yaml.Unmarshal([]byte(yamlString), &input)
+	err := yamlv4.Unmarshal([]byte(yamlString), &input)
 	s.Require().NoError(err)
 
 	internalData := NewInput(input)

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -4,13 +4,13 @@
 package test
 
 import (
-	"go.yaml.in/yaml/v4"
+	yamlv4 "go.yaml.in/yaml/v4"
 )
 
 // GetTestFromYaml will get the tests to be processed from a YAML string.
 func GetTestFromYaml(testYaml []byte, fileName string) (ftwTest *FTWTest, err error) {
 	ftwTest = &FTWTest{}
-	err = yaml.Unmarshal(testYaml, ftwTest)
+	err = yamlv4.Unmarshal(testYaml, ftwTest)
 	if err != nil {
 		return nil, err
 	}

--- a/test/yaml_test.go
+++ b/test/yaml_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
-	"go.yaml.in/yaml/v4"
+	yamlv4 "go.yaml.in/yaml/v4"
 )
 
 type yamlTestSuite struct {
@@ -53,7 +53,7 @@ tests:
 	yamlString := fmt.Sprintf(yamlTemplate, key, value)
 	test := &FTWTest{}
 
-	err := yaml.Unmarshal([]byte(yamlString), test)
+	err := yamlv4.Unmarshal([]byte(yamlString), test)
 	s.Require().NoError(err)
 
 	//nolint:staticcheck
@@ -83,7 +83,7 @@ tests:
 `
 	test := &FTWTest{}
 
-	err := yaml.Unmarshal([]byte(yamlString), test)
+	err := yamlv4.Unmarshal([]byte(yamlString), test)
 	s.Require().NoError(err)
 
 	//nolint:staticcheck


### PR DESCRIPTION
Use aliases for major version upgrades of dependencies to prevent issues for users (e.g., Coraza) when using go-ftw as a library.