### PR TITLE
feat: support follow_redirect

### DIFF
--- a/runner/redirect.go
+++ b/runner/redirect.go
@@ -1,0 +1,120 @@
+// Copyright 2024 OWASP CRS Project
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/coreruleset/go-ftw/v2/ftwhttp"
+	"github.com/coreruleset/go-ftw/v2/test"
+	"github.com/rs/zerolog/log"
+)
+
+// RedirectLocation represents a parsed redirect location
+type RedirectLocation struct {
+	Protocol string
+	Host     string
+	Port     int
+	URI      string
+}
+
+// extractRedirectLocation parses the Location header from a redirect response
+// and returns the parsed components (protocol, host, port, URI).
+// It handles both absolute and relative URLs.
+func extractRedirectLocation(response *ftwhttp.Response, baseInput *test.Input) (*RedirectLocation, error) {
+	if response == nil {
+		return nil, fmt.Errorf("no previous response available for redirect")
+	}
+
+	// Check if status code is a redirect (3xx)
+	statusCode := response.Parsed.StatusCode
+	if statusCode < 300 || statusCode >= 400 {
+		return nil, fmt.Errorf("previous response status code %d is not a redirect (3xx)", statusCode)
+	}
+
+	// Get Location header
+	location := response.Parsed.Header.Get("Location")
+	if location == "" {
+		return nil, fmt.Errorf("previous response is a redirect but has no Location header")
+	}
+
+	log.Debug().Msgf("Following redirect to: %s", location)
+
+	// Parse the location URL
+	locationURL, err := url.Parse(location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Location header '%s': %w", location, err)
+	}
+
+	result := &RedirectLocation{}
+
+	// If the URL is relative (no scheme/host), use the base URL from the original request
+	if !locationURL.IsAbs() {
+		result.Protocol = baseInput.GetProtocol()
+		result.Host = baseInput.GetDestAddr()
+		result.Port = baseInput.GetPort()
+
+		// Handle relative URIs
+		if strings.HasPrefix(location, "/") {
+			result.URI = location
+		} else {
+			// Relative to current path - merge with base URI
+			baseURI := baseInput.GetURI()
+			lastSlash := strings.LastIndex(baseURI, "/")
+			if lastSlash >= 0 {
+				result.URI = baseURI[:lastSlash+1] + location
+			} else {
+				result.URI = "/" + location
+			}
+		}
+	} else {
+		// Absolute URL - extract all components
+		result.Protocol = locationURL.Scheme
+		result.Host = locationURL.Hostname()
+
+		// Extract port
+		portStr := locationURL.Port()
+		if portStr != "" {
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid port in Location header: %s", portStr)
+			}
+			result.Port = port
+		} else {
+			// Use default port based on scheme
+			if result.Protocol == "https" {
+				result.Port = 443
+			} else {
+				result.Port = 80
+			}
+		}
+
+		// Construct URI (path + query + fragment)
+		result.URI = locationURL.RequestURI()
+	}
+
+	log.Debug().Msgf("Parsed redirect: protocol=%s, host=%s, port=%d, uri=%s",
+		result.Protocol, result.Host, result.Port, result.URI)
+
+	return result, nil
+}
+
+// applyRedirectToInput modifies the test input to follow a redirect
+func applyRedirectToInput(input *test.Input, redirect *RedirectLocation) {
+	// Override destination with redirect location
+	input.Protocol = &redirect.Protocol
+	input.DestAddr = &redirect.Host
+	input.Port = &redirect.Port
+	input.URI = &redirect.URI
+
+	// Update Host header to match the new destination
+	headers := input.GetHeaders()
+	headers.Set("Host", redirect.Host)
+
+	log.Debug().Msgf("Applied redirect to input: %s://%s:%d%s",
+		redirect.Protocol, redirect.Host, redirect.Port, redirect.URI)
+}

--- a/runner/redirect.go
+++ b/runner/redirect.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/coreruleset/go-ftw/v2/ftwhttp"
 	"github.com/coreruleset/go-ftw/v2/test"
@@ -30,10 +29,13 @@ func extractRedirectLocation(response *ftwhttp.Response, baseInput *test.Input) 
 		return nil, fmt.Errorf("no previous response available for redirect")
 	}
 
-	// Check if status code is a redirect (3xx)
+	// Check if status code is a redirect
 	statusCode := response.Parsed.StatusCode
-	if statusCode < 300 || statusCode >= 400 {
-		return nil, fmt.Errorf("previous response status code %d is not a redirect (3xx)", statusCode)
+	switch statusCode {
+	case 300, 301, 302, 303, 307, 308:
+		// valid redirect status codes
+	default:
+		return nil, fmt.Errorf("previous response status code %d is not a redirect", statusCode)
 	}
 
 	// Get Location header
@@ -52,50 +54,47 @@ func extractRedirectLocation(response *ftwhttp.Response, baseInput *test.Input) 
 
 	result := &RedirectLocation{}
 
-	// If the URL is relative (no scheme/host), use the base URL from the original request
-	if !locationURL.IsAbs() {
-		result.Protocol = baseInput.GetProtocol()
-		result.Host = baseInput.GetDestAddr()
-		result.Port = baseInput.GetPort()
-
-		// Handle relative URIs
-		if strings.HasPrefix(location, "/") {
-			result.URI = location
-		} else {
-			// Relative to current path - merge with base URI
-			baseURI := baseInput.GetURI()
-			lastSlash := strings.LastIndex(baseURI, "/")
-			if lastSlash >= 0 {
-				result.URI = baseURI[:lastSlash+1] + location
-			} else {
-				result.URI = "/" + location
-			}
-		}
-	} else {
-		// Absolute URL - extract all components
-		result.Protocol = locationURL.Scheme
-		result.Host = locationURL.Hostname()
-
-		// Extract port
-		portStr := locationURL.Port()
-		if portStr != "" {
-			port, err := strconv.Atoi(portStr)
-			if err != nil {
-				return nil, fmt.Errorf("invalid port in Location header: %s", portStr)
-			}
-			result.Port = port
-		} else {
-			// Use default port based on scheme
-			if result.Protocol == "https" {
-				result.Port = 443
-			} else {
-				result.Port = 80
-			}
-		}
-
-		// Construct URI (path + query + fragment)
-		result.URI = locationURL.RequestURI()
+	// Build base URL from the previous request for resolving relative redirects
+	baseURL := &url.URL{
+		Scheme: baseInput.GetProtocol(),
+		Host:   baseInput.GetDestAddr(),
+		Path:   baseInput.GetURI(),
 	}
+	
+	// Add port to host if it's not a default port
+	port := baseInput.GetPort()
+	isDefaultPort := (baseURL.Scheme == "https" && port == 443) ||
+		(baseURL.Scheme == "http" && port == 80)
+	if !isDefaultPort {
+		baseURL.Host = fmt.Sprintf("%s:%d", baseURL.Host, port)
+	}
+
+	// Resolve the location URL against the base URL
+	resolvedURL := baseURL.ResolveReference(locationURL)
+
+	// Extract components from resolved URL
+	result.Protocol = resolvedURL.Scheme
+	result.Host = resolvedURL.Hostname()
+
+	// Extract port
+	portStr := resolvedURL.Port()
+	if portStr != "" {
+		parsedPort, err := strconv.Atoi(portStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid port in Location header: %s", portStr)
+		}
+		result.Port = parsedPort
+	} else {
+		// Use default port based on scheme
+		if result.Protocol == "https" {
+			result.Port = 443
+		} else {
+			result.Port = 80
+		}
+	}
+
+	// Construct URI (path + query); fragments are not included in RequestURI
+	result.URI = resolvedURL.RequestURI()
 
 	log.Debug().Msgf("Parsed redirect: protocol=%s, host=%s, port=%d, uri=%s",
 		result.Protocol, result.Host, result.Port, result.URI)
@@ -111,9 +110,17 @@ func applyRedirectToInput(input *test.Input, redirect *RedirectLocation) {
 	input.Port = &redirect.Port
 	input.URI = &redirect.URI
 
-	// Update Host header to match the new destination
+	// Update Host header to match the new destination, including non-default ports
 	headers := input.GetHeaders()
-	headers.Set("Host", redirect.Host)
+
+	hostHeader := redirect.Host
+	isDefaultPort := (redirect.Protocol == "https" && redirect.Port == 443) ||
+		(redirect.Protocol == "http" && redirect.Port == 80)
+	if !isDefaultPort {
+		hostHeader = fmt.Sprintf("%s:%d", redirect.Host, redirect.Port)
+	}
+
+	headers.Set("Host", hostHeader)
 
 	log.Debug().Msgf("Applied redirect to input: %s://%s:%d%s",
 		redirect.Protocol, redirect.Host, redirect.Port, redirect.URI)

--- a/runner/redirect.go
+++ b/runner/redirect.go
@@ -28,6 +28,9 @@ func extractRedirectLocation(response *ftwhttp.Response, baseInput *test.Input) 
 	if response == nil {
 		return nil, fmt.Errorf("no previous response available for redirect")
 	}
+	if baseInput == nil {
+		return nil, fmt.Errorf("no previous input available for redirect resolution")
+	}
 
 	// Check if status code is a redirect
 	statusCode := response.Parsed.StatusCode
@@ -43,7 +46,6 @@ func extractRedirectLocation(response *ftwhttp.Response, baseInput *test.Input) 
 	if location == "" {
 		return nil, fmt.Errorf("previous response is a redirect but has no Location header")
 	}
-
 	log.Debug().Msgf("Following redirect to: %s", location)
 
 	// Parse the location URL
@@ -60,7 +62,7 @@ func extractRedirectLocation(response *ftwhttp.Response, baseInput *test.Input) 
 		Host:   baseInput.GetDestAddr(),
 		Path:   baseInput.GetURI(),
 	}
-	
+
 	// Add port to host if it's not a default port
 	port := baseInput.GetPort()
 	isDefaultPort := (baseURL.Scheme == "https" && port == 443) ||

--- a/runner/redirect_test.go
+++ b/runner/redirect_test.go
@@ -1,0 +1,316 @@
+// Copyright 2024 OWASP CRS Project
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"net/http"
+	"testing"
+
+	schema "github.com/coreruleset/ftw-tests-schema/v2/types"
+	"github.com/coreruleset/go-ftw/v2/ftwhttp"
+	"github.com/coreruleset/go-ftw/v2/test"
+	"github.com/stretchr/testify/suite"
+)
+
+type redirectTestSuite struct {
+	suite.Suite
+}
+
+func TestRedirectTestSuite(t *testing.T) {
+	suite.Run(t, new(redirectTestSuite))
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_AbsoluteURL() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 302,
+			Header: http.Header{
+				"Location": []string{"https://newdomain.com:8443/newpath?query=value"},
+			},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("https", result.Protocol)
+	s.Equal("newdomain.com", result.Host)
+	s.Equal(8443, result.Port)
+	s.Equal("/newpath?query=value", result.URI)
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_AbsoluteURLWithDefaultPort() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 301,
+			Header: http.Header{
+				"Location": []string{"https://newdomain.com/newpath"},
+			},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("https", result.Protocol)
+	s.Equal("newdomain.com", result.Host)
+	s.Equal(443, result.Port)
+	s.Equal("/newpath", result.URI)
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_RelativeURLAbsolutePath() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 8080
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 302,
+			Header: http.Header{
+				"Location": []string{"/newpath"},
+			},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("http", result.Protocol)
+	s.Equal("example.com", result.Host)
+	s.Equal(8080, result.Port)
+	s.Equal("/newpath", result.URI)
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_RelativeURLRelativePath() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/path/to/resource"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 302,
+			Header: http.Header{
+				"Location": []string{"newresource"},
+			},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("http", result.Protocol)
+	s.Equal("example.com", result.Host)
+	s.Equal(80, result.Port)
+	s.Equal("/path/to/newresource", result.URI)
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_NoResponse() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	result, err := extractRedirectLocation(nil, baseInput)
+	s.Error(err)
+	s.Nil(result)
+	s.Contains(err.Error(), "no previous response available")
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_NotRedirectStatus() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 200,
+			Header: http.Header{
+				"Location": []string{"/newpath"},
+			},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.Error(err)
+	s.Nil(result)
+	s.Contains(err.Error(), "not a redirect")
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_NoLocationHeader() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 302,
+			Header:     http.Header{},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.Error(err)
+	s.Nil(result)
+	s.Contains(err.Error(), "no Location header")
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_HTTPToHTTPS() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	response := &ftwhttp.Response{
+		Parsed: http.Response{
+			StatusCode: 301,
+			Header: http.Header{
+				"Location": []string{"https://example.com/secure"},
+			},
+		},
+	}
+
+	result, err := extractRedirectLocation(response, baseInput)
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("https", result.Protocol)
+	s.Equal("example.com", result.Host)
+	s.Equal(443, result.Port)
+	s.Equal("/secure", result.URI)
+}
+
+func (s *redirectTestSuite) TestApplyRedirectToInput() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	input := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	redirect := &RedirectLocation{
+		Protocol: "https",
+		Host:     "newdomain.com",
+		Port:     8443,
+		URI:      "/newpath",
+	}
+
+	applyRedirectToInput(input, redirect)
+
+	s.Equal("https", input.GetProtocol())
+	s.Equal("newdomain.com", input.GetDestAddr())
+	s.Equal(8443, input.GetPort())
+	s.Equal("/newpath", input.GetURI())
+
+	// Check Host header was updated
+	headers := input.GetHeaders()
+	hostHeaders := headers.GetAll("Host")
+	s.Len(hostHeaders, 1)
+	s.Equal("newdomain.com", hostHeaders[0].Value)
+}
+
+func (s *redirectTestSuite) TestExtractRedirectLocation_Various3xxCodes() {
+	protocol := "http"
+	destAddr := "example.com"
+	port := 80
+	uri := "/original"
+
+	baseInput := test.NewInput(&schema.Input{
+		Protocol: &protocol,
+		DestAddr: &destAddr,
+		Port:     &port,
+		URI:      &uri,
+	})
+
+	redirectCodes := []int{300, 301, 302, 303, 307, 308}
+
+	for _, code := range redirectCodes {
+		response := &ftwhttp.Response{
+			Parsed: http.Response{
+				StatusCode: code,
+				Header: http.Header{
+					"Location": []string{"/redirect"},
+				},
+			},
+		}
+
+		result, err := extractRedirectLocation(response, baseInput)
+		s.NoError(err, "Failed for status code %d", code)
+		s.NotNil(result, "Result is nil for status code %d", code)
+		s.Equal("/redirect", result.URI)
+	}
+}

--- a/runner/run.go
+++ b/runner/run.go
@@ -79,9 +79,10 @@ func RunTest(runContext *TestRunContext, ftwTest *test.FTWTest) error {
 			continue
 		}
 		runContext.StartTest()
-		// Clear previous response when starting a new test
+		// Clear previous response and input when starting a new test
 		// (follow_redirect should only work within the same test case)
 		runContext.LastStageResponse = nil
+		runContext.LastStageInput = nil
 
 		test.ApplyPlatformOverrides(runContext.RunnerConfig, &testCase)
 		// this is just for printing once the next test
@@ -143,20 +144,20 @@ func RunStage(runContext *TestRunContext, ftwCheck *FTWCheck, testCase schema.Te
 		return err
 	}
 
-	// Handle follow_redirect if enabled
-	if stage.Input.FollowRedirect != nil && *stage.Input.FollowRedirect {
-		redirectLocation, err := extractRedirectLocation(runContext.LastStageResponse, testInput)
-		if err != nil {
-			return fmt.Errorf("follow_redirect enabled but failed to extract redirect location: %w", err)
-		}
-		applyRedirectToInput(testInput, redirectLocation)
-	}
-
 	// Do not even run test if result is overridden. Directly set and display the overridden result.
 	if overridden := overriddenTestResult(ftwCheck, &testCase); overridden != Failed {
 		runContext.Result = overridden
 		displayResult(&testCase, runContext, overridden, time.Duration(0))
 		return nil
+	}
+
+	// Handle follow_redirect if enabled
+	if stage.Input.FollowRedirect != nil && *stage.Input.FollowRedirect {
+		redirectLocation, err := extractRedirectLocation(runContext.LastStageResponse, runContext.LastStageInput)
+		if err != nil {
+			return fmt.Errorf("follow_redirect enabled but failed to extract redirect location: %w", err)
+		}
+		applyRedirectToInput(testInput, redirectLocation)
 	}
 
 	// Destination is needed for a request
@@ -221,8 +222,9 @@ func RunStage(runContext *TestRunContext, ftwCheck *FTWCheck, testCase schema.Te
 	}
 	runContext.EndStage(&testCase, testResult, triggeredRules)
 
-	// Store the response for potential use by follow_redirect in next stage
+	// Store the response and input for potential use by follow_redirect in next stage
 	runContext.LastStageResponse = response
+	runContext.LastStageInput = testInput
 
 	// show the result unless quiet was passed in the command line
 	displayResult(&testCase, runContext, testResult, roundTripTime)

--- a/runner/run.go
+++ b/runner/run.go
@@ -79,6 +79,9 @@ func RunTest(runContext *TestRunContext, ftwTest *test.FTWTest) error {
 			continue
 		}
 		runContext.StartTest()
+		// Clear previous response when starting a new test
+		// (follow_redirect should only work within the same test case)
+		runContext.LastStageResponse = nil
 
 		test.ApplyPlatformOverrides(runContext.RunnerConfig, &testCase)
 		// this is just for printing once the next test
@@ -138,6 +141,15 @@ func RunStage(runContext *TestRunContext, ftwCheck *FTWCheck, testCase schema.Te
 	// Check sanity first
 	if err := checkTestSanity(&stage); err != nil {
 		return err
+	}
+
+	// Handle follow_redirect if enabled
+	if stage.Input.FollowRedirect != nil && *stage.Input.FollowRedirect {
+		redirectLocation, err := extractRedirectLocation(runContext.LastStageResponse, testInput)
+		if err != nil {
+			return fmt.Errorf("follow_redirect enabled but failed to extract redirect location: %w", err)
+		}
+		applyRedirectToInput(testInput, redirectLocation)
 	}
 
 	// Do not even run test if result is overridden. Directly set and display the overridden result.
@@ -208,6 +220,9 @@ func RunStage(runContext *TestRunContext, ftwCheck *FTWCheck, testCase schema.Te
 		return err
 	}
 	runContext.EndStage(&testCase, testResult, triggeredRules)
+
+	// Store the response for potential use by follow_redirect in next stage
+	runContext.LastStageResponse = response
 
 	// show the result unless quiet was passed in the command line
 	displayResult(&testCase, runContext, testResult, roundTripTime)

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 
@@ -344,6 +345,73 @@ func (s *runTestSuite) TestOverrideRun() {
 	res, err := Run(s.runnerConfig, s.ftwTests, s.out)
 	s.Require().NoError(err)
 	s.LessOrEqual(0, res.Stats.TotalFailed(), "Oops, test run failed!")
+}
+
+func (s *runTestSuite) TestFollowRedirect() {
+	// Track which URIs were requested to validate redirect behavior
+	var requestedURIs []string
+	var requestedHosts []string
+	var mu sync.Mutex
+
+	// Custom handler that returns a redirect on first request
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedURIs = append(requestedURIs, r.RequestURI)
+		requestedHosts = append(requestedHosts, r.Host)
+		mu.Unlock()
+
+		// Don't track marker requests
+		if r.Header.Get(s.cfg.LogMarkerHeaderName) != "" {
+			s.writeMarkerOrMessageToTestServerLog(logText, r)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.RequestURI == "/redirect-me" {
+			// Stage 1: Return relative redirect to /redirected
+			w.Header().Set("Location", "/redirected")
+			w.WriteHeader(http.StatusFound)
+			_, _ = w.Write([]byte("Redirecting..."))
+		} else if r.RequestURI == "/redirected" {
+			// Stage 2: Return success
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Success after redirect"))
+		} else {
+			// Unexpected URI
+			w.WriteHeader(http.StatusNotFound)
+		}
+
+		s.writeMarkerOrMessageToTestServerLog(logText, r)
+	}
+
+	s.ts.Config.Handler = http.HandlerFunc(handler)
+
+	s.runnerConfig.Output = output.Quiet
+	res, err := Run(s.runnerConfig, s.ftwTests, s.out)
+	s.Require().NoError(err)
+	s.Equal(0, res.Stats.TotalFailed(), "Follow redirect test should pass")
+
+	// Verify that both URIs were requested (excluding marker requests)
+	mu.Lock()
+	actualRequests := []string{}
+	actualHosts := []string{}
+	for i, uri := range requestedURIs {
+		if uri != "/status/200" { // Skip marker requests
+			actualRequests = append(actualRequests, uri)
+			actualHosts = append(actualHosts, requestedHosts[i])
+		}
+	}
+	mu.Unlock()
+
+	s.Require().Len(actualRequests, 2, "Should have made 2 non-marker requests")
+	s.Equal("/redirect-me", actualRequests[0], "First request should be to /redirect-me")
+	s.Equal("/redirected", actualRequests[1], "Second request should be to /redirected (redirect target)")
+
+	// Verify Host headers
+	s.Require().Len(actualHosts, 2, "Should have captured 2 Host headers")
+	// First request uses Host from test yaml (just IP, no port)
+	// Second request (after redirect) should include port for non-default port
+	s.Contains(actualHosts[1], ":", "Host header should include port after redirect for non-default port")
 }
 
 func (s *runTestSuite) TestBrokenOverrideRun() {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"text/template"
 
@@ -351,37 +350,35 @@ func (s *runTestSuite) TestFollowRedirect() {
 	// Track which URIs were requested to validate redirect behavior
 	var requestedURIs []string
 	var requestedHosts []string
-	var mu sync.Mutex
 
 	// Custom handler that returns a redirect on first request
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
 		requestedURIs = append(requestedURIs, r.RequestURI)
 		requestedHosts = append(requestedHosts, r.Host)
-		mu.Unlock()
 
 		// Don't track marker requests
 		if r.Header.Get(s.cfg.LogMarkerHeaderName) != "" {
-			s.writeMarkerOrMessageToTestServerLog(logText, r)
+			s.writeMarkerOrMessageToTestServerLog(runTestLogLines, r)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 
-		if r.RequestURI == "/redirect-me" {
+		switch r.RequestURI {
+		case "/redirect-me":
 			// Stage 1: Return relative redirect to /redirected
 			w.Header().Set("Location", "/redirected")
 			w.WriteHeader(http.StatusFound)
 			_, _ = w.Write([]byte("Redirecting..."))
-		} else if r.RequestURI == "/redirected" {
+		case "/redirected":
 			// Stage 2: Return success
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("Success after redirect"))
-		} else {
+		default:
 			// Unexpected URI
 			w.WriteHeader(http.StatusNotFound)
 		}
 
-		s.writeMarkerOrMessageToTestServerLog(logText, r)
+		s.writeMarkerOrMessageToTestServerLog(runTestLogLines, r)
 	}
 
 	s.ts.Config.Handler = http.HandlerFunc(handler)
@@ -392,7 +389,6 @@ func (s *runTestSuite) TestFollowRedirect() {
 	s.Equal(0, res.Stats.TotalFailed(), "Follow redirect test should pass")
 
 	// Verify that both URIs were requested (excluding marker requests)
-	mu.Lock()
 	actualRequests := []string{}
 	actualHosts := []string{}
 	for i, uri := range requestedURIs {
@@ -401,7 +397,6 @@ func (s *runTestSuite) TestFollowRedirect() {
 			actualHosts = append(actualHosts, requestedHosts[i])
 		}
 	}
-	mu.Unlock()
 
 	s.Require().Len(actualRequests, 2, "Should have made 2 non-marker requests")
 	s.Equal("/redirect-me", actualRequests[0], "First request should be to /redirect-me")

--- a/runner/testdata/TestFollowRedirect.yaml
+++ b/runner/testdata/TestFollowRedirect.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  author: "tester"
+  description: "Test follow_redirect functionality"
+tests:
+  - test_id: 1
+    description: "Test redirect following between stages"
+    stages:
+      # Stage 1: Initial request that returns a redirect
+      - input:
+          dest_addr: "{{ .TestAddr }}"
+          port: {{ .TestPort }}
+          uri: "/redirect-me"
+          headers:
+            User-Agent: "go-ftw test"
+            Host: "{{ .TestAddr }}"
+        output:
+          expect_error: False
+          status: 302
+      # Stage 2: Follow the redirect from stage 1
+      - input:
+          follow_redirect: true
+          headers:
+            User-Agent: "go-ftw test"
+        output:
+          expect_error: False
+          status: 200

--- a/runner/types.go
+++ b/runner/types.go
@@ -34,6 +34,9 @@ type TestRunContext struct {
 	LogLines               *waflog.FTWLogLines
 	CurrentStageDuration   time.Duration
 	currentStageStartTime  time.Time
+	// LastStageResponse stores the response from the previous stage,
+	// used for follow_redirect functionality
+	LastStageResponse *ftwhttp.Response
 }
 
 func (t *TestRunContext) StartTest() {

--- a/runner/types.go
+++ b/runner/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coreruleset/go-ftw/v2/config"
 	"github.com/coreruleset/go-ftw/v2/ftwhttp"
 	"github.com/coreruleset/go-ftw/v2/output"
+	"github.com/coreruleset/go-ftw/v2/test"
 	"github.com/coreruleset/go-ftw/v2/waflog"
 )
 
@@ -37,6 +38,9 @@ type TestRunContext struct {
 	// LastStageResponse stores the response from the previous stage,
 	// used for follow_redirect functionality
 	LastStageResponse *ftwhttp.Response
+	// LastStageInput stores the input from the previous stage,
+	// used as base for resolving relative redirects
+	LastStageInput *test.Input
 }
 
 func (t *TestRunContext) StartTest() {


### PR DESCRIPTION
## what

- implement remaining `follow_redirect` boolean from schema

## why

- support all schema features

## refs

- fixes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-stage tests can now follow HTTP redirects using the `follow_redirect` option, with automatic handling of redirect chains and updates to protocol, destination, port, and request headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coreruleset/go-ftw/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->