### PR TITLE
feat: support custom regex for rule id lookup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
@@ -9,3 +9,6 @@ insert_final_newline = true
 
 [*.yaml]
 indent_size = 2
+
+[*.{go,mod,sum}]
+indent_style = tab

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ func NewDefaultConfig() *FTWConfiguration {
 		RunMode:             DefaultRunMode,
 		MaxMarkerRetries:    DefaultMaxMarkerRetries,
 		MaxMarkerLogLines:   DefaultMaxMarkerLogLines,
+		CustomLogIdRegex:    "",
 	}
 }
 

--- a/config/runner_config.go
+++ b/config/runner_config.go
@@ -46,6 +46,7 @@ type RunnerConfig struct {
 	// SkipTlsVerification skips certificate validation. Useful for connecting
 	// to domains with a self-signed certificate.
 	SkipTlsVerification bool
+	CustomLogIdRegex    string
 }
 
 type PlatformOverrides struct {
@@ -62,6 +63,7 @@ func NewRunnerConfiguration(cfg *FTWConfiguration) *RunnerConfig {
 		MaxMarkerRetries:    cfg.MaxMarkerRetries,
 		RunMode:             cfg.RunMode,
 		SkipTlsVerification: cfg.SkipTlsVerification,
+		CustomLogIdRegex:    cfg.CustomLogIdRegex,
 	}
 
 	if cfg.IncludeTests != nil {

--- a/config/types.go
+++ b/config/types.go
@@ -48,6 +48,8 @@ type FTWConfiguration struct {
 	IncludeTags *FTWRegexp `koanf:"include_tags"`
 	// to domains with a self-signed certificate.
 	SkipTlsVerification bool `koanf:"skip_tls_verification"`
+	// CustomLogIdRegex is a regular expression used to look for rule IDs when reading the WAF logs
+	CustomLogIdRegex string `koanf:"custom_log_id_regex"`
 }
 
 // FTWTestOverride holds four lists:

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -42,18 +42,13 @@ func (ll *FTWLogLines) TriggeredRules() []uint {
 
 	lines := ll.getMarkedLines()
 
+	lineMatcher := ll.matchLine
+	if ll.customLogIdRegex != nil {
+		lineMatcher = ll.matchLineCustom
+	}
 	for _, line := range lines {
 		log.Trace().Msgf("ftw/waflog: Looking for any rule in '%s'", line)
-		// Only execute custom regex if defined, otherwise fallback to the default std + json regexes
-		regex := ll.customLogIdRegex
-		if regex == nil {
-			regex = stdLogIdRegex
-		}
-		match := regex.FindAllSubmatch(line, -1)
-		if match == nil && ll.customLogIdRegex == nil {
-			regex = jsonLogIdRegex
-			match = regex.FindAllSubmatch(line, -1)
-		}
+		match := lineMatcher(line)
 		for _, nextMatch := range match {
 			submatchBytes := nextMatch[1]
 			if len(submatchBytes) == 0 {
@@ -80,6 +75,19 @@ func (ll *FTWLogLines) TriggeredRules() []uint {
 		delete(ruleIdsSet, key)
 	}
 	return ll.triggeredRules
+}
+
+func (ll *FTWLogLines) matchLine(line []byte) [][][]byte {
+	match := stdLogIdRegex.FindAllSubmatch(line, -1)
+	if match == nil {
+		match = jsonLogIdRegex.FindAllSubmatch(line, -1)
+	}
+
+	return match
+}
+
+func (ll *FTWLogLines) matchLineCustom(line []byte) [][][]byte {
+	return ll.customLogIdRegex.FindAllSubmatch(line, -1)
 }
 
 // ContainsAllIds returns true if all of the specified rule IDs appear in the log for the current test.

--- a/waflog/read.go
+++ b/waflog/read.go
@@ -44,9 +44,13 @@ func (ll *FTWLogLines) TriggeredRules() []uint {
 
 	for _, line := range lines {
 		log.Trace().Msgf("ftw/waflog: Looking for any rule in '%s'", line)
-		regex := stdLogIdRegex
+		// Only execute custom regex if defined, otherwise fallback to the default std + json regexes
+		regex := ll.customLogIdRegex
+		if regex == nil {
+			regex = stdLogIdRegex
+		}
 		match := regex.FindAllSubmatch(line, -1)
-		if match == nil {
+		if match == nil && ll.customLogIdRegex == nil {
 			regex = jsonLogIdRegex
 			match = regex.FindAllSubmatch(line, -1)
 		}

--- a/waflog/read_test.go
+++ b/waflog/read_test.go
@@ -503,3 +503,34 @@ func (s *readTestSuite) TestFalsePositiveIds() {
 	s.Len(foundRuleIds, 1)
 	s.Contains(foundRuleIds, uint(942370))
 }
+
+func (s *readTestSuite) TestFTWLogLines_CustomLogIdRegex() {
+	cfg, err := config.NewConfigFromEnv()
+	s.Require().NoError(err)
+	s.NotNil(cfg)
+
+	startMarker, endMarker := generateLogMarkers(100000, 1)
+	startMarkerLine := "X-cRs-TeSt: " + startMarker
+	endMarkerLine := "X-cRs-TeSt: " + endMarker
+	logLinesOnly :=
+		`[Tue Jan 05 02:21:09.637165 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Pattern match "\\\\b(?:keep-alive|close),\\\\s?(?:keep-alive|close)\\\\b" at REQUEST_HEADERS:Connection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "339"] [id "920210"] [msg "Multiple/Conflicting Connection Header Data Found"] [data "close,close"] [severity "WARNING"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
+[Tue Jan 05 02:21:09.637731 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Match of "pm AppleWebKit Android" against "REQUEST_HEADERS:User-Agent" required. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1230"] [id="920300"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "capec/1000/210/272"] [tag "PCI/6.5.10"] [tag "paranoia-level/2"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]
+[Tue Jan 05 02:21:09.638572 2021] [:error] [pid 76:tid 139683434571520] [client 172.23.0.1:58998] [client 172.23.0.1] ModSecurity: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "91"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [hostname "localhost"] [uri "/"] [unique_id "X-PNFSe1VwjCgYRI9FsbHgAAAIY"]`
+	logLines := fmt.Sprintf("%s\n%s\n%s", startMarkerLine, logLinesOnly, endMarkerLine)
+	s.filename, err = utils.CreateTempFileWithContent("", logLines, "test-errorlog-")
+	s.Require().NoError(err)
+
+	cfg.LogFile = s.filename
+	runnerConfig := config.NewRunnerConfiguration(cfg)
+
+	ll, err := NewFTWLogLines(runnerConfig)
+	s.Require().NoError(err)
+	ll.WithStartMarker(bytes.ToLower([]byte(startMarkerLine)))
+	ll.WithEndMarker(bytes.ToLower([]byte(endMarkerLine)))
+	err = ll.WithCustomLogIdRegex(`\[id="(\d+)"\]`)
+	s.Require().NoError(err)
+
+	foundRuleIds := ll.TriggeredRules()
+	s.Len(foundRuleIds, 1)
+	s.Contains(foundRuleIds, uint(920300))
+}

--- a/waflog/types.go
+++ b/waflog/types.go
@@ -6,7 +6,7 @@ package waflog
 
 import (
 	"os"
-
+	"regexp"
 	"slices"
 
 	"github.com/coreruleset/go-ftw/v2/config"
@@ -24,6 +24,7 @@ type FTWLogLines struct {
 	markedLinesInitialized    bool
 	triggeredRulesInitialized bool
 	runMode                   config.RunMode
+	customLogIdRegex          *regexp.Regexp
 }
 
 func (ll *FTWLogLines) StartMarker() []byte {
@@ -41,4 +42,5 @@ func (ll *FTWLogLines) reset() {
 	ll.markedLines = slices.Delete(ll.markedLines, 0, len(ll.markedLines))
 	ll.markedLinesInitialized = false
 	ll.triggeredRulesInitialized = false
+	ll.customLogIdRegex = nil
 }

--- a/waflog/types.go
+++ b/waflog/types.go
@@ -42,5 +42,4 @@ func (ll *FTWLogLines) reset() {
 	ll.markedLines = slices.Delete(ll.markedLines, 0, len(ll.markedLines))
 	ll.markedLinesInitialized = false
 	ll.triggeredRulesInitialized = false
-	ll.customLogIdRegex = nil
 }

--- a/waflog/waflog.go
+++ b/waflog/waflog.go
@@ -87,7 +87,7 @@ func compileAndCheckRegex(regex string) (*regexp.Regexp, error) {
 		return nil, fmt.Errorf("could not parse regular expression: %w", err)
 	}
 	if regexAst.MaxCap() == 0 {
-	  return nil, errors.New("regex does not contain a capture group and cannot be used to find IDs")
+		return nil, errors.New("regex does not contain a capture group and cannot be used to find IDs")
 	}
 
 	compiled, err := regexp.Compile(regex)

--- a/waflog/waflog.go
+++ b/waflog/waflog.go
@@ -8,16 +8,23 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
+	"regexp/syntax"
 
 	"github.com/coreruleset/go-ftw/v2/config"
 )
 
 // NewFTWLogLines is the base struct for reading the log file
 func NewFTWLogLines(cfg *config.RunnerConfig) (*FTWLogLines, error) {
+	customLogIdRegex, err := compileAndCheckRegex(cfg.CustomLogIdRegex)
+	if cfg.CustomLogIdRegex != "" && err != nil {
+		return nil, fmt.Errorf("custom log id regex: %w", err)
+	}
 	ll := &FTWLogLines{
 		logFilePath:         cfg.LogFilePath,
 		runMode:             cfg.RunMode,
 		LogMarkerHeaderName: bytes.ToLower([]byte(cfg.LogMarkerHeaderName)),
+		customLogIdRegex:    customLogIdRegex,
 	}
 
 	if err := ll.openLogFile(); err != nil {
@@ -42,6 +49,15 @@ func (ll *FTWLogLines) WithEndMarker(marker []byte) {
 	ll.endMarker = bytes.ToLower(marker)
 }
 
+func (ll *FTWLogLines) WithCustomLogIdRegex(regex string) error {
+	compiledRegex, err := compileAndCheckRegex(regex)
+	if err != nil {
+		return fmt.Errorf("custom log id regex: %w", err)
+	}
+	ll.customLogIdRegex = compiledRegex
+	return nil
+}
+
 // Cleanup closes the log file
 func (ll *FTWLogLines) Cleanup() error {
 	if ll != nil && ll.logFile != nil {
@@ -60,4 +76,24 @@ func (ll *FTWLogLines) openLogFile() error {
 		}
 	}
 	return nil
+}
+
+func compileAndCheckRegex(regex string) (*regexp.Regexp, error) {
+	if regex == "" {
+		return nil, nil
+	}
+	regexAst, err := syntax.Parse(regex, syntax.Perl)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse regular expression: %w", err)
+	}
+	if regexAst.MaxCap() == 0 {
+	  return nil, errors.New("regex does not contain a capture group and cannot be used to find IDs")
+	}
+
+	compiled, err := regexp.Compile(regex)
+	if err != nil {
+		return nil, fmt.Errorf("could not compile regular expression: %w", err)
+	}
+
+	return compiled, nil
 }

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -79,3 +79,85 @@ func (s *waflogTestSuite) TestLogLinesReset() {
 	s.Empty(ll.markedLines)
 	s.Nil(ll.customLogIdRegex)
 }
+
+func (s *waflogTestSuite) TestCompileAndCheckRegex() {
+	tests := []struct {
+		name        string
+		regex       string
+		expectNil   bool
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "empty string returns nil without error",
+			regex:       "",
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:        "valid regex with capture group",
+			regex:       `(\d+)`,
+			expectNil:   false,
+			expectError: false,
+		},
+		{
+			name:        "valid regex with named capture group",
+			regex:       `(?P<id>\d+)`,
+			expectNil:   false,
+			expectError: false,
+		},
+		{
+			name:        "valid regex with multiple capture groups",
+			regex:       `(\d+)-([a-z]+)`,
+			expectNil:   false,
+			expectError: false,
+		},
+		{
+			name:        "invalid regex syntax returns parse error",
+			regex:       `[invalid`,
+			expectNil:   true,
+			expectError: true,
+			errorMsg:    "could not parse regular expression",
+		},
+		{
+			name:        "regex without capture group returns error",
+			regex:       `\d+`,
+			expectNil:   true,
+			expectError: true,
+			errorMsg:    "regex does not contain a capture group and cannot be used to find IDs",
+		},
+		{
+			name:        "regex with only non-capturing group returns error",
+			regex:       `(?:\d+)`,
+			expectNil:   true,
+			expectError: true,
+			errorMsg:    "regex does not contain a capture group and cannot be used to find IDs",
+		},
+		{
+			name:        "complex valid regex with capture group",
+			regex:       `^prefix-([a-zA-Z0-9]+)-suffix$`,
+			expectNil:   false,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			result, err := compileAndCheckRegex(tt.regex)
+
+			if tt.expectError {
+				s.Require().Error(err)
+				s.Contains(err.Error(), tt.errorMsg)
+				s.Nil(result)
+			} else {
+				s.Require().NoError(err)
+			}
+
+			if tt.expectNil {
+				s.Nil(result)
+			} else {
+				s.NotNil(result)
+			}
+		})
+	}
+}

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -77,4 +77,5 @@ func (s *waflogTestSuite) TestLogLinesReset() {
 	s.Nil(ll.endMarker)
 	s.Empty(ll.triggeredRules)
 	s.Empty(ll.markedLines)
+	s.Nil(ll.customLogIdRegex)
 }

--- a/waflog/waflog_test.go
+++ b/waflog/waflog_test.go
@@ -5,6 +5,7 @@ package waflog
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -68,6 +69,7 @@ func (s *waflogTestSuite) TestLogLinesReset() {
 		endMarker:           []byte("endmarker"),
 		triggeredRules:      []uint{1, 3, 3},
 		markedLines:         [][]byte{[]byte("line1"), []byte("line2")},
+		customLogIdRegex:    regexp.MustCompile(""),
 	}
 
 	ll.reset()
@@ -77,7 +79,7 @@ func (s *waflogTestSuite) TestLogLinesReset() {
 	s.Nil(ll.endMarker)
 	s.Empty(ll.triggeredRules)
 	s.Empty(ll.markedLines)
-	s.Nil(ll.customLogIdRegex)
+	s.NotNil(ll.customLogIdRegex)
 }
 
 func (s *waflogTestSuite) TestCompileAndCheckRegex() {


### PR DESCRIPTION
I have the same issue with #614 and created this PR in response :D. The PR adds both regexes used for rule id lookup into the global configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom regular expressions to identify and extract rule IDs from WAF logs, for flexible log parsing.
  * Ability to configure or update the custom log-ID regex after initialization.

* **Tests**
  * Added tests covering custom regex extraction and validation (valid and invalid patterns).

* **Chores**
  * Editor config updated to use tab indentation for Go-related files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coreruleset/go-ftw/pull/628)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->