### PR TITLE
fix: fail instead of skipping unparseable test files

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/kaptinlin/go-i18n v0.1.4 h1:wCiwAn1LOcvymvWIVAM4m5dUAMiHunTdEubLDk4hT
 github.com/kaptinlin/go-i18n v0.1.4/go.mod h1:g1fn1GvTgT4CiLE8/fFE1hboHWJ6erivrDpiDtCcFKg=
 github.com/kaptinlin/jsonschema v0.4.6 h1:vOSFg5tjmfkOdKg+D6Oo4fVOM/pActWu/ntkPsI1T64=
 github.com/kaptinlin/jsonschema v0.4.6/go.mod h1:1DUd7r5SdyB2ZnMtyB7uLv64dE3zTFTiYytDCd+AEL0=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
 github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=

--- a/test/files.go
+++ b/test/files.go
@@ -5,6 +5,7 @@ package test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path"
 
@@ -37,9 +38,7 @@ func GetTestsFromFiles(globPattern string) ([]*FTWTest, error) {
 		}
 		ftwTest, err := GetTestFromYaml(yamlString, fileName)
 		if err != nil {
-			log.Warn().Msgf("Problem detected in file %s:\n%v\n",
-				filePath, err)
-			continue
+			return tests, fmt.Errorf("problem detected in file %s: %w", filePath, err)
 		}
 
 		tests = append(tests, ftwTest)

--- a/test/files_test.go
+++ b/test/files_test.go
@@ -92,3 +92,17 @@ func (s *filesTestSuite) TestGetFromBadYAML() {
 
 	s.Error(err, "reading yaml should fail")
 }
+
+// A single unparseable file must fail the whole run, even when other files in
+// the glob parse fine. Skipping it silently hides the loss of test coverage.
+func (s *filesTestSuite) TestGetFromBadYAMLAmongGoodFiles() {
+	_, err := utils.CreateTempFileWithContent(s.tempDir, yamlTest, "good-*.yaml")
+	s.Require().NoError(err)
+	bad, err := utils.CreateTempFileWithContent(s.tempDir, wrongYamlTest, "bad-*.yaml")
+	s.Require().NoError(err)
+
+	_, err = GetTestsFromFiles(s.tempDir + "/*.yaml")
+
+	s.Require().Error(err, "an unparseable file must not be skipped")
+	s.Contains(err.Error(), bad, "error should name the offending file")
+}


### PR DESCRIPTION
## what

`GetTestsFromFiles` logged a YAML parse error as a warning and skipped the file. It now returns the error, so `check` and `run` fail on an unparseable test file instead of quietly running a smaller suite.

This restores the behaviour the function's own doc comment already described:

```go
// If some file has yaml error, will stop processing and
// return the error with the partial list of files read.
```

Also tidies `go.sum` (stale `klauspost/compress v1.18.0` entries left by the v1.18.7 bump in #659) in a separate commit — pre-existing on `main`, but the `go-mod-tidy` hook fails without it.

## why

A parse error silently deleted a rule's entire test coverage while CI stayed green. This happened for real on [coreruleset/coreruleset#4755](https://github.com/coreruleset/coreruleset/pull/4755): a `\/` escape in a double-quoted scalar made `913100.yaml` unparseable, its nine tests stopped running, and both `regression (modsec2-apache)` and `regression (modsec3-nginx)` passed having tested nothing. Once the YAML was fixed, one of those tests failed — a real engine-divergence bug the suite should have caught.

`run` was the worse of the two: the dropped file wasn't even counted in `⏭ skipped 0 tests`.

## before / after

Two files in a directory, one valid and one with a YAML syntax error:

```console
# before
$ go-ftw check -d ./mixed
WRN Problem detected in file ./mixed/913100.yaml:
yaml: ... found unknown escape character
ftw/check: checked 1 files, everything looks good!
$ echo $?
0

$ go-ftw run -d ./mixed
...
➕ run 8 total tests in 129.202959ms
⏭ skipped 0 tests
🎉 All tests successful!
$ echo $?
0
```

```console
# after
$ go-ftw check -d ./mixed
Error: problem detected in file ./mixed/913100.yaml: yaml: ... found unknown escape character
$ echo $?
1

$ go-ftw run -d ./mixed
Error: problem detected in file ./mixed/913100.yaml: yaml: ... found unknown escape character
$ echo $?
1
```

The all-files-fail path still returns `no tests found` as before.

## tests

`TestGetFromBadYAMLAmongGoodFiles` covers the case the existing `TestGetFromBadYAML` missed: the old code passed that test only because a single bad file left zero tests and tripped the `no tests found` branch. The new test puts a bad file alongside a good one, which is the case that used to slip through, and asserts the error names the offending file.

Verified it fails without the fix:

```
--- FAIL: TestFilesTestSuite/TestGetFromBadYAMLAmongGoodFiles
    Error: An error is expected but got nil.
    Messages: an unparseable file must not be skipped
```

## refs

- fixes #660
- surfaced by coreruleset/coreruleset#4755

## ai disclosure

- **tools used**: Claude (Opus 5)
- **assisted with**: reproducing the behaviour and capturing exit codes, the `test/files.go` change, `TestGetFromBadYAMLAmongGoodFiles`, drafting this description
- **review performed**: read all four call sites of `GetTestsFromFiles` to confirm both commands propagate the error and no caller depended on the skip; reverted the fix in the working tree and confirmed the new test fails, then reinstated it and confirmed it passes; ran the full `go test ./...` suite (all packages green), `go vet ./...`, `golangci-lint run ./test/...` (0 issues), and the pre-commit hook set; built the binary and ran it against the real coreruleset repro — `check` now exits 1 naming the file on the PR branch, and still exits 0 with `checked 322 files` on clean `main`, confirming no false positives; confirmed the `go.sum` drift is pre-existing on `main` and unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test discovery now stops and reports an error when any YAML test file cannot be parsed.
  * Error messages identify the file that caused the parsing failure.

* **Tests**
  * Added coverage for mixed valid and invalid YAML files to ensure parsing errors are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->