### PR TITLE
fix(output): emit valid GitHub Actions workflow commands for -o github

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -26,6 +26,15 @@ const (
 	Markdown Type = "markdown" // markdown-friendly plain text
 )
 
+// AnnotationSeverity is the severity of a GitHub Actions workflow command.
+type AnnotationSeverity string
+
+const (
+	AnnotationNotice  AnnotationSeverity = "notice"
+	AnnotationWarning AnnotationSeverity = "warning"
+	AnnotationError   AnnotationSeverity = "error"
+)
+
 type catalog map[string]string
 
 // this catalog is used to translate text from basic terminals to enhanced ones that support emoji, just
@@ -53,6 +62,8 @@ type Output struct {
 	OutputType Type
 	cat        catalog
 	w          io.Writer
+	// severity is the severity used for GitHub annotation commands.
+	severity AnnotationSeverity
 }
 
 // ValidTypes returns an array of the valid output types.
@@ -73,16 +84,37 @@ func (o *Output) Printf(format string, a ...interface{}) error {
 	case Quiet, JSON:
 		// don't print anything
 		return nil
-	case GitHub:
-		s = fmt.Sprintf(format, a...)
-		s = fmt.Sprintf("::notice file={name},line={line},endLine={endLine},title={title}::{%s}", s)
 	case Plain, Markdown:
 		s = fmt.Sprintf(format, a...)
+	case GitHub:
+		s = fmt.Sprintf(format, a...)
+		// Println appends the line break to the format string; that break
+		// must stay a real newline so each workflow command sits on its own
+		// line. Only the message body gets escaped.
+		if strings.HasSuffix(s, "\n") {
+			s = githubCommand(string(o.severity), strings.TrimSuffix(s, "\n")) + "\n"
+		} else {
+			s = githubCommand(string(o.severity), s)
+		}
 	default:
 		s = emoji.Sprintf(format, a...)
 	}
 	_, _ = fmt.Fprintf(o.w, "%s", s)
 	return nil
+}
+
+// githubCommand formats a GitHub Actions workflow command (annotation).
+func githubCommand(severity, message string) string {
+	return "::" + severity + "::" + escapeWorkflow(message)
+}
+
+// escapeWorkflow URL-encodes the characters that are not allowed inside a
+// GitHub workflow command. Order matters: '%' must be escaped first.
+func escapeWorkflow(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
 }
 
 func (o *Output) RawPrint(s string) {
@@ -96,11 +128,13 @@ func NewOutput(o string, w io.Writer) *Output {
 		OutputType: Normal,
 		cat:        normalCatalog,
 		w:          w,
+		severity:   AnnotationNotice,
 	}
 	switch strings.ToLower(o) {
 	case "quiet":
 		out.OutputType = Quiet
 	case "github":
+		out.cat = createPlainCatalog(normalCatalog)
 		out.OutputType = GitHub
 	case "json":
 		out.OutputType = JSON
@@ -134,6 +168,11 @@ func (o *Output) IsJson() bool {
 
 func (o *Output) IsMarkdown() bool {
 	return o.OutputType == Markdown
+}
+
+// SetSeverity overrides the severity used for GitHub annotation commands.
+func (o *Output) SetSeverity(severity AnnotationSeverity) {
+	o.severity = severity
 }
 
 func createPlainCatalog(c catalog) catalog {

--- a/output/output.go
+++ b/output/output.go
@@ -88,14 +88,11 @@ func (o *Output) Printf(format string, a ...interface{}) error {
 		s = fmt.Sprintf(format, a...)
 	case GitHub:
 		s = fmt.Sprintf(format, a...)
-		// Println appends the line break to the format string; that break
-		// must stay a real newline so each workflow command sits on its own
-		// line. Only the message body gets escaped.
-		if strings.HasSuffix(s, "\n") {
-			s = githubCommand(string(o.severity), strings.TrimSuffix(s, "\n")) + "\n"
-		} else {
-			s = githubCommand(string(o.severity), s)
-		}
+		// Every command must occupy its own line: terminate partial writes
+		// (Printf without a trailing newline, e.g. the "running <id>: "
+		// progress prefix) so they cannot swallow the next command, and
+		// keep Println's line break real. Only the message body is escaped.
+		s = githubCommand(string(o.severity), strings.TrimSuffix(s, "\n")) + "\n"
 	default:
 		s = emoji.Sprintf(format, a...)
 	}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -77,3 +77,40 @@ func (s *outputTestSuite) TestPlainCatalogOutput() {
 		b.Reset()
 	}
 }
+
+func (s *outputTestSuite) TestGitHubAnnotationError() {
+	var b bytes.Buffer
+	o := NewOutput("github", &b)
+	o.SetSeverity(AnnotationError)
+
+	err := o.Printf("- %s failed in %s", "920100-1", "5ms")
+	s.Require().NoError(err)
+	// file/line/endLine are deliberately omitted: go-ftw has no per-test
+	// line info, and a file without a line renders as a misleading `#L0`.
+	s.Equal("::error::- 920100-1 failed in 5ms", b.String())
+}
+
+func (s *outputTestSuite) TestGitHubAnnotationEscapesSpecialChars() {
+	var b bytes.Buffer
+	o := NewOutput("github", &b)
+
+	err := o.Printf("100%% done\r\nwith: %s, ok", "newline")
+	s.Require().NoError(err)
+	// Only '%', CR and LF are escaped in the message body (per the actions
+	// runner): ':' and ',' pass through untouched.
+	s.Equal("::notice::100%25 done%0D%0Awith: newline, ok", b.String())
+}
+
+// Println's line break must remain a real newline: GitHub only parses one
+// workflow command per line, so escaping it would glue every command into a
+// single (rejected) annotation.
+func (s *outputTestSuite) TestGitHubAnnotationPrintlnKeepsRealNewline() {
+	var b bytes.Buffer
+	o := NewOutput("github", &b)
+
+	err := o.Println("+ passed in %s", "5ms")
+	s.Require().NoError(err)
+	err = o.Println("- failed")
+	s.Require().NoError(err)
+	s.Equal("::notice::+ passed in 5ms\n::notice::- failed\n", b.String())
+}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -114,3 +114,18 @@ func (s *outputTestSuite) TestGitHubAnnotationPrintlnKeepsRealNewline() {
 	s.Require().NoError(err)
 	s.Equal("::notice::+ passed in 5ms\n::notice::- failed\n", b.String())
 }
+
+// A Printf without a trailing newline (run.go's "\trunning %s: " progress
+// prefix) must become a complete command on its own line instead of letting
+// the next command be parsed as part of its message.
+func (s *outputTestSuite) TestGitHubPartialPrintfDoesNotSwallowNextCommand() {
+	var b bytes.Buffer
+	o := NewOutput("github", &b)
+
+	err := o.Printf("\trunning %s: ", "920100-1")
+	s.Require().NoError(err)
+	o.SetSeverity(AnnotationError)
+	err = o.Println("- %s failed in %s (RTT %s)", "920100-1", "5ms", "2ms")
+	s.Require().NoError(err)
+	s.Equal("::notice::\trunning 920100-1: \n::error::- 920100-1 failed in 5ms (RTT 2ms)\n", b.String())
+}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -87,7 +87,7 @@ func (s *outputTestSuite) TestGitHubAnnotationError() {
 	s.Require().NoError(err)
 	// file/line/endLine are deliberately omitted: go-ftw has no per-test
 	// line info, and a file without a line renders as a misleading `#L0`.
-	s.Equal("::error::- 920100-1 failed in 5ms", b.String())
+	s.Equal("::error::- 920100-1 failed in 5ms\n", b.String())
 }
 
 func (s *outputTestSuite) TestGitHubAnnotationEscapesSpecialChars() {
@@ -98,7 +98,7 @@ func (s *outputTestSuite) TestGitHubAnnotationEscapesSpecialChars() {
 	s.Require().NoError(err)
 	// Only '%', CR and LF are escaped in the message body (per the actions
 	// runner): ':' and ',' pass through untouched.
-	s.Equal("::notice::100%25 done%0D%0Awith: newline, ok", b.String())
+	s.Equal("::notice::100%25 done%0D%0Awith: newline, ok\n", b.String())
 }
 
 // Println's line break must remain a real newline: GitHub only parses one

--- a/runner/run.go
+++ b/runner/run.go
@@ -355,12 +355,15 @@ func checkTestSanity(stage *schema.Stage) error {
 }
 
 func displayResult(testCase *schema.Test, rc *TestRunContext, result TestResult, roundTripTime time.Duration) {
+	// Always reset to notice afterwards so other output is not mislabeled.
+	defer rc.Output.SetSeverity(output.AnnotationNotice)
 	switch result {
 	case Success:
 		if !rc.ShowOnlyFailed {
 			rc.Output.Println(rc.Output.Message("+ passed in %s (RTT %s)"), rc.CurrentStageDuration, roundTripTime)
 		}
 	case Failed:
+		rc.Output.SetSeverity(output.AnnotationError)
 		rc.Output.Println(rc.Output.Message("- %s failed in %s (RTT %s)"), testCase.IdString(), rc.CurrentStageDuration, roundTripTime)
 	case Ignored:
 		if !rc.ShowOnlyFailed {


### PR DESCRIPTION
## What

Fix the `github` output type so it emits valid GitHub Actions workflow
commands instead of malformed ones.

Before (broken — unsubstituted placeholders, stray braces, GitHub drops
the command):

```
::notice file={name},line={line},endLine={endLine},title={title}::{+ passed in 148ms (RTT 84ms)}
```

After:

```
::notice::+ passed in 148ms (RTT 84ms)
::error::- 999999-1 failed in 149ms (RTT 85ms)
```

Changes in `output/output.go`:

- replace the broken wrapper with a `githubCommand` builder emitting
  `::severity::message`
- escape the message body per the actions runner (`%` → `%25`,
  `\r` → `%0D`, `\n` → `%0A`); keep `Println`'s line break as a real
  newline so each command sits on its own line
- add an `AnnotationSeverity` type (`notice`/`warning`/`error`) with a
  `SetSeverity` setter

Changes in `runner/run.go`:

- `displayResult` reports failed tests as `::error::` and resets to
  `notice` afterwards

`NewOutput` uses the plain catalog for github output so `:emoji:` codes
from the normal catalog do not leak into annotation text.

## Why

`-o github` is meant to surface test results as GitHub annotations. The
current output is rejected by Actions, so the feature silently produces
nothing.

Fixes #663

## Testing

- `output`/`runner` unit tests, including new cases for the command
  format, escaping (`%`, CR, LF), error severity and the real-newline
  handling in `Println`
- validated end-to-end in a real Actions run of the CRS regression suite
  (ModSecurity IIS connector, ~4900 tests): failures rendered as error
  annotations, summary lines as notices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Actions annotations now support notice, warning, and error severity levels.
  * Failed results are reported as error annotations, while other output remains notice-level by default.

* **Bug Fixes**
  * Annotation messages now safely handle special characters, including percent signs and line breaks.
  * Multiple annotations remain separately parseable when printed together.
  * Error annotations no longer include unnecessary file and line details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->