### PR TITLE
docs: add ADR for benchmark mode

### DIFF
--- a/docs/adr/0001-benchmark-mode.md
+++ b/docs/adr/0001-benchmark-mode.md
@@ -34,8 +34,8 @@ The reported need is profiling and latency data, not concurrent regression asser
 ## Decision
 
 Add a benchmark mode that fires the requests from existing YAML test files concurrently, up to a
-configurable concurrency limit, and reports aggregate latency/throughput stats
-(min/max/avg/percentiles, requests/sec) instead of per-test pass/fail.
+configurable concurrency limit, and reports aggregate latency/throughput stats instead of
+per-test pass/fail.
 
 - No start/end log markers and no log tailing in this mode — WAF log correlation is exactly the
   part that doesn't work under concurrency, so this mode doesn't attempt it.
@@ -44,6 +44,22 @@ configurable concurrency limit, and reports aggregate latency/throughput stats
   `corpus` subcommand pattern, rather than a flag on `run`. Its output (stats) and semantics (no
   pass/fail) differ enough from regression testing that folding it into `run` would overload one
   command with two unrelated output modes.
+- Concurrency applies at the test level: independent `FTWTest` instances run concurrently, up to
+  the configured limit. Stages within a single test stay sequential, since later stages can
+  depend on earlier ones (e.g. `follow_redirect`, shared connection state) — a multi-stage test
+  is one unit of concurrency, not N.
+- Per-request latency is measured from connection start (including TLS handshake, since that's
+  real overhead a WAF proxy adds) through sending the request and consuming the full response
+  body. Time spent queued waiting for a free concurrency slot is excluded from per-request
+  latency, but does count toward the overall requests/sec figure, since that's wall-clock
+  throughput for the whole run.
+- Reported stats: min/avg/max and p50/p90/p99 latency, plus overall requests/sec.
+- A request that completes — any response fully received, including an expected WAF block (e.g.
+  403) — counts toward latency and throughput stats; bench mode isn't asserting correctness, so a
+  block response is a normal completion, not a failure. A request that errors out (connection
+  failure, timeout, malformed response) is excluded from latency stats and counted separately as
+  an error rather than silently dropped, so a spike in failures doesn't disappear as an
+  implausibly fast average.
 
 ## Consequences
 

--- a/docs/adr/0001-benchmark-mode.md
+++ b/docs/adr/0001-benchmark-mode.md
@@ -1,0 +1,69 @@
+# 1. Benchmark mode: concurrent request firing without per-request log correlation
+
+Date: 2026-09-08
+
+## Status
+
+Proposed
+
+## Context
+
+[#143](https://github.com/coreruleset/go-ftw/issues/143) asks for a way to send N requests
+concurrently, so go-ftw can be used to profile and debug WAF latency under load, using
+realistic test data (existing YAML test files) instead of a separate load-testing tool.
+
+`go-ftw run` executes stages strictly one at a time (`runner/run.go:130`, `RunStage`). Each
+request is bracketed by a start/end log marker, and a single tailed log reader
+(`runContext.LogLines`) is grepped for that marker window to correlate WAF log output back to
+the request (`runner/run.go:243`, `markAndFlush`). This only works because requests are
+serialized: concurrent requests would interleave their markers in the log, so a marker window
+could no longer be trusted to contain only that request's log lines.
+
+Reliable per-request correctness checking under concurrency needs a different correlation
+mechanism — e.g. a unique transaction ID that the WAF connector echoes in a response header, so
+the corresponding log lines can be found by ID instead of by "everything between marker A and
+marker B" (raised by the issue reporter and by airween in the issue thread). That depends on
+connector behavior go-ftw doesn't control and is a materially larger change.
+
+The existing `--max-concurrency` flag on `corpus`/`quantitative`/`raw` doesn't transfer here: it
+drives an in-process Coraza engine per goroutine (`internal/quantitative/local_engine.go`), with
+no external log tailing involved.
+
+The reported need is profiling and latency data, not concurrent regression assertions.
+
+## Decision
+
+Add a benchmark mode that fires the requests from existing YAML test files concurrently, up to a
+configurable concurrency limit, and reports aggregate latency/throughput stats
+(min/max/avg/percentiles, requests/sec) instead of per-test pass/fail.
+
+- No start/end log markers and no log tailing in this mode — WAF log correlation is exactly the
+  part that doesn't work under concurrency, so this mode doesn't attempt it.
+- Reuse the existing test-file loader (`test.FTWTest`) and `ftwhttp.Client` — no new HTTP layer.
+- Ship as a new `go-ftw bench` subcommand, following the existing `run` / `quantitative` /
+  `corpus` subcommand pattern, rather than a flag on `run`. Its output (stats) and semantics (no
+  pass/fail) differ enough from regression testing that folding it into `run` would overload one
+  command with two unrelated output modes.
+
+## Consequences
+
+**Positive:** satisfies the reported need (latency/throughput profiling against real test data)
+with an additive change that doesn't touch the existing `run` assertion path; no dependency on
+WAF connectors changing behavior.
+
+**Negative:** benchmark mode cannot verify that a rule fired correctly for any individual
+concurrent request — it only reports that requests completed, and how fast. It is not a
+replacement for `run`.
+
+**Deferred:** true concurrent regression testing (per-request correctness under concurrency, via
+unique transaction ID correlation) is tracked as a possible follow-up, contingent on WAF
+connectors exposing that ID in a response header. Not part of this decision.
+
+## Alternatives considered
+
+- **Unique transaction ID correlation** (issue's option 2): rejected for now — requires WAF
+  connector support go-ftw doesn't control, and reworking `CheckLogForMarker` to key by ID
+  instead of a start/end window. Larger scope than the reported need.
+- **Flag on the existing `run` command**: rejected — `run`'s output is pass/fail per test;
+  benchmark mode's output is aggregate stats. Different enough to warrant a separate subcommand
+  rather than a mode switch inside `run`.


### PR DESCRIPTION
## what

Adds an ADR proposing a `bench` mode: fire requests from existing YAML test
files concurrently and report aggregate latency/throughput stats, without
per-request WAF log correlation.

## why

Closes #143. Concurrent requests would interleave the start/end log markers
`run` currently uses for per-request correlation (`runner/run.go`), so
correctness checking under concurrency needs a different mechanism (a
per-transaction ID from the WAF connector) that's out of scope here. This ADR
scopes the change down to what the issue actually asked for: profiling and
latency data, not concurrent regression assertions.

## refs

- #143

cc @jcchavezs — would like to iterate on this with you before it's built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the benchmark-mode architecture decision record.
  * Documents concurrency at the individual test-case level rather than the YAML-file level.
  * Specifies that test cases are scheduled up to the configured in-flight limit, while stages within each multi-stage test remain sequential.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->